### PR TITLE
assignipvm form render

### DIFF
--- a/backend/apps/kloudust/lib/cmd/cmdconstants.js
+++ b/backend/apps/kloudust/lib/cmd/cmdconstants.js
@@ -9,4 +9,4 @@ exports.FALSE_RESULT = (err="", out="") => {return {result: false, err, out}};
 exports.TRUE_RESULT = (out="", err="") => {return {result: true, err, out}};
 exports.SCRIPT_JSONOUT_SPLITTER = "-----KLOUDUST_JSON_OUT-----";
 exports.PROJECT_EXCLUDED_COMMANDS = ["getUserProjects", "addHost", "rebootHost", "addImage", "addUser", "lookupHost", 
-    "listHostResources", "listVMsForHost", "customCmd", "changeUserRole", "liveMigrate", "listVMImages"]
+    "listHostResources", "listVMsForHost", "customCmd", "changeUserRole", "liveMigrate", "listVMImages","assignIPToVM"]

--- a/frontend/apps/kloudust/commands/forms/assignipvm.form.json
+++ b/frontend/apps/kloudust/commands/forms/assignipvm.form.json
@@ -59,7 +59,7 @@
     "required_label": "{{{i18n.Required}}}",
     "required_fields": [
     {"id": "vm_name", "type": "text", "placeholder": "{{{i18n.VMName}}}", "required": true, 
-        "pattern":"\\s[0-9a-zA-Z]+\\s", "validation_error": "{{{i18n.FieldValidationErrorGeneric}}}",
+        "pattern":"\\s[0-9a-zA-Z-]+\\s", "validation_error": "{{{i18n.FieldValidationErrorGeneric}}}",
         "value":"{{{APP_CONSTANTS.ENV._vms_form_data.name_raw}}}", 
         "readonly":"{{#APP_CONSTANTS.ENV._vms_form_data.name_raw}}true{{/APP_CONSTANTS.ENV._vms_form_data.name_raw}}"},
     {"id": "ip", "type": "text", "placeholder": "{{{i18n.VMAssignIPCommand}}}", "required": true, 

--- a/frontend/apps/kloudust/commands/forms/create.form.json
+++ b/frontend/apps/kloudust/commands/forms/create.form.json
@@ -9,6 +9,7 @@
     {"id": "addimage", "label": "{{{i18n.AddImage}}}", "logo": "img/addimage.svg"}
 ],
 "*": [
+    {"id": "assignipvm", "label": "{{{i18n.AssignIPtoVM}}}", "logo": "img/assignipvm.svg"},
     {"id": "createvm", "label": "{{{i18n.CreateVirtualMachine}}}", "logo": "img/createvm.svg"},
     {"id": "createvnet", "label": "{{{i18n.CreateVirtualNetwork}}}", "logo": "img/createvnet.svg"},
     {"id": "createfirewall", "label": "{{{i18n.CreateFirewall}}}", "logo": "img/createfirewall.svg"},
@@ -26,6 +27,7 @@
 "en": {
     "AddHost": "Add host",
     "AddImage": "Add image",
+    "AssignIPtoVM": "Assign IP to VM",
     "CreateVirtualMachine": "Virtual machine",
     "CreateVirtualNetwork": "Virtual network",
     "CreateFirewall": "Firewall Ruleset",
@@ -40,6 +42,7 @@
 "hi": {
     "AddHost": "Add host",
     "AddImage": "Add image",
+    "AssignIPtoVM": "Assign IP to VM",
     "CreateVirtualMachine": "Virtual machine",
     "CreateVirtualNetwork": "Virtual network",
     "CreateFirewall": "Firewall Ruleset",
@@ -53,6 +56,7 @@
 "ja": {
     "AddHost": "Add host",
     "AddImage": "Add image",
+    "AssignIPtoVM": "Assign IP to VM",
     "CreateVirtualMachine": "Virtual machine",
     "CreateVirtualNetwork": "Virtual network",
     "CreateFirewall": "Firewall Ruleset",
@@ -67,6 +71,7 @@
 "zh": {
     "AddHost": "Add host",
     "AddImage": "Add image",
+    "AssignIPtoVM": "Assign IP to VM",
     "CreateVirtualMachine": "Virtual machine",
     "CreateVirtualNetwork": "Virtual network",
     "CreateFirewall": "Firewall Ruleset",


### PR DESCRIPTION
Changes in cmdconstants.js and create.form.json files will render the option of assigning IP to VM in create section of kloudust.

one regex change has been done in the assignipvm.form.json file.
The previous regex caused the validation error because it demands a space before and after the VM's name. 