### PR TITLE
Minor Fix : Incorrect Backend URL if frontend port is any other than 443 or 80

### DIFF
--- a/frontend/apps/kloudust/js/constants.mjs
+++ b/frontend/apps/kloudust/js/constants.mjs
@@ -4,7 +4,7 @@
  * License: See enclosed license.txt file.
  */
 const FRONTEND = new URL(window.location).protocol + "//" + new URL(window.location).host;
-const BACKEND = new URL(window.location).protocol + "//" + new URL(window.location).host + ":9090";
+const BACKEND = new URL(window.location).protocol + "//" + new URL(window.location).hostname + ":9090";
 const APP_NAME = "kloudust";
 const APP_PATH = `${FRONTEND}/apps/${APP_NAME}`;
 const API_PATH = `${BACKEND}/apps/${APP_NAME}`;


### PR DESCRIPTION
 ```new URL(window.location).host```  contains both hostname and port, whereas  ```new URL(window.location).hostname``` only contains the hostname.