### PR TITLE
Fix : SSH port update in addHost for Ubuntu 24+

### DIFF
--- a/backend/apps/kloudust/lib/cmd/scripts/addHost.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/addHost.sh
@@ -199,6 +199,7 @@ fi
 if ! sed -i 's/^#\?[ ]*[Pp]ort[ ]\+[0-9]\+[ ]*$//g' /etc/ssh/sshd_config; then exitFailed; fi
 if ! echo "Port $NEW_SSH_PORT" >> /etc/ssh/sshd_config; then exitFailed; fi
 if ! touch ~/.hushlogin; then exitFailed; fi
+if ! sudo systemctl daemon-reload; then exitFailed; fi
 if [ -f "`which yum`" ]; then 
     if ! sudo systemctl restart sshd; then exitFailed; fi
 else 


### PR DESCRIPTION
Previously, during the addHost process, Kloudust would update a host's SSH port to a random value. However, in Ubuntu 24+ the SSH port binding mechanism changed, causing this process to fail.

This update fixes the issue by ensuring SSH port updates work correctly on both Ubuntu 24+ and earlier versions.

Testing:
Verified on Ubuntu 24+ and pre-24 versions.