### PR TITLE
Modified : run-parts to allow files with '.' in the name to execute

### DIFF
--- a/backend/apps/kloudust/lib/cmd/scripts/addHost.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/addHost.sh
@@ -177,7 +177,7 @@ After=multi-user.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/run-parts /kloudust/system
+ExecStart=/usr/bin/run-parts --regex ".*" /kloudust/system
 
 [Install]
 WantedBy=multi-user.target

--- a/backend/apps/kloudust/lib/cmd/scripts/addOrModifyVxLANBridge.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/addOrModifyVxLANBridge.sh
@@ -80,4 +80,6 @@ if ! ip link set up dev $BR_NAME; then exitFailed; fi                           
 echo Brought up VxLAN $VLAN_NAME and bridge $BR_NAME
 
 cp $SCRIPT_PATH $VXLAN_BOOT_SCRIPT                                               # Ensure we survive a boot
+chmod +x $VXLAN_BOOT_SCRIPT
+
 echo Done.


### PR DESCRIPTION
By default run-parts doesn't allow files that have a '.' in the name to execute, also run-parts requires the files to be executable