### PR TITLE
Minor Fix : the grep command is prone to grepping incorrect core info

### DIFF
--- a/backend/apps/kloudust/lib/cmd/scripts/addHost.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/addHost.sh
@@ -29,7 +29,7 @@ function saveNFTables() {
 }
 
 function printConfig() {
-    CORESPERCPU=`lscpu | grep Core | tr -s " " | cut -d":" -f2 | xargs`
+    CORESPERCPU=`lscpu | grep "Core(s) per socket" | tr -s " " | cut -d":" -f2 | xargs`
     SOCKETS=`lscpu | grep Socket | tr -s " " | cut -d":" -f2 | xargs`
     CORES=`lscpu | grep CPU | tr -s " " | cut -d":" -f2 | xargs`
     PROCESSORMAKER=`lscpu | grep 'Vendor ID' | tr -s " " | cut -d":" -f2 | xargs`


### PR DESCRIPTION
The command was prone to grepping incorrect info
example screenshot attached
<img width="1920" height="141" alt="Screenshot from 2025-12-05 19-16-50" src="https://github.com/user-attachments/assets/96937dbb-cbca-4e18-a04b-37f45cbe80d5" />
