### PR TITLE
Fix : Assigning private IP to VM which is in two different vnets

### DIFF
--- a/backend/apps/kloudust/lib/cmd/scripts/assignVMIPViaVnet.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/assignVMIPViaVnet.sh
@@ -51,7 +51,7 @@ cat > /etc/netplan/99-kd-ip-'${IP_ADDRESS_UNDERSCORES}'.yaml <<NETPLAN_EOF
     "version": 2,
     "renderer": "networkd",
     "ethernets": {
-      "private": {
+      "private_'${IP_ADDRESS_UNDERSCORES}'": {
         "match": {"macaddress": "'${MAC_ADDRESS}'"},
         "dhcp4": false,
 	      "mtu": '${MTU}',


### PR DESCRIPTION
What this fixes

When a vm was in two different vnets at the same time, the private ip was always getting assigned to the latter vnet due to netplan config grouping this fixes it by creating separate groupings