### PR TITLE
Fix to hostchooser, correct resource usage calculation

### DIFF
--- a/backend/apps/kloudust/lib/dbAbstractor.js
+++ b/backend/apps/kloudust/lib/dbAbstractor.js
@@ -202,9 +202,9 @@ exports.getHostEntry = async hostname => {
  *  * @param {string} arch The required archictecture of the host
  * @return {hostname, cpu, memory} or null
  */
-exports.getAvailableHost = async (vcpu,ram,arch) => {
+exports.getAvailableHost = async (vcpu,ram,arch,factors) => {
     if (!roleman.checkAccess(roleman.ACTIONS.lookup_cloud_resource_for_project)) {_logUnauthorized(); return false; }
-    const query = `SELECT h.hostname, (h.cores - IFNULL(SUM(v.cpus), 0)) AS free_cpu, (h.memory - IFNULL(SUM(v.memory), 0)) AS free_ram FROM hosts h LEFT JOIN vms v ON v.hostname = h.hostname WHERE h.processorarchitecture = ? GROUP BY h.hostname HAVING free_cpu >= ? and free_ram >= ? ORDER BY free_cpu DESC, free_ram DESC LIMIT 1;`;
+    const query = `SELECT h.hostname, (h.cores * ${factors.cpu_factor} - IFNULL(SUM(v.cpus), 0)) AS free_cpu, (h.memory * ${factors.mem_factor} - IFNULL(SUM(v.memory) * 1024 * 1024, 0)) AS free_ram FROM hosts h LEFT JOIN vms v ON v.hostname = h.hostname WHERE h.processorarchitecture = ? GROUP BY h.hostname HAVING free_cpu >= ? and free_ram >= ? ORDER BY free_cpu DESC, free_ram DESC LIMIT 1;`;
     const host = await _db().getQuery(query, [arch,vcpu,ram]);
     return host;
 }

--- a/backend/apps/kloudust/lib/hostchooser.js
+++ b/backend/apps/kloudust/lib/hostchooser.js
@@ -13,9 +13,7 @@ const dbAbstractor = require(`${KLOUD_CONSTANTS.LIBDIR}/dbAbstractor.js`);
 exports.getHostFor = async function(vcpus, memory, disk, imagearchitecture) {
     const cpu_factor = KLOUD_CONSTANTS.CONF.VCPU_TO_PHYSICAL_CPU_FACTOR;
     const mem_factor = KLOUD_CONSTANTS.CONF.VMEM_TO_PHYSICAL_MEM_FACTOR;
-    vcpus = Math.ceil(vcpus / cpu_factor);
-    memory = Math.ceil((memory * 1024 * 1024) / mem_factor); //convert megabytes to bytes
-    const available_host = await dbAbstractor.getAvailableHost(vcpus,memory,imagearchitecture); 
+    const available_host = await dbAbstractor.getAvailableHost(vcpus,memory,imagearchitecture, {cpu_factor,mem_factor}); 
     if (available_host.length == 0) {return false}
     return await dbAbstractor.getHostEntry(available_host[0].hostname);
 }


### PR DESCRIPTION
The dbAbstractor functions must receive the factors to correctly calculate the free resources, the previously implementation works correctly meaning distributes vms evenly but the issue happens when sum(vms.cpu) or sum(vms.memory) goes above real host resources, found today during testing