### PR TITLE
Fixes for roleenforcer canBeSetupMode

### DIFF
--- a/backend/apps/kloudust/lib/dbAbstractor.js
+++ b/backend/apps/kloudust/lib/dbAbstractor.js
@@ -25,7 +25,7 @@ exports.getUserCount = async _ => {
     if (user_count == 0) return user_count; // this is a special case when the Kloud has no users at all
     
     // if we have users already then we must lookup the role permissions
-    if (!roleman.checkAccess(roleman.ACTIONS.lookup_cloud_resource)) {_logUnauthorized(); return 0;}
+    if (!roleman.checkAccess(roleman.ACTIONS.lookup_cloud_resource)) {_logUnauthorized(); return false;}
     else return user_count;
 }
 

--- a/backend/apps/kloudust/lib/roleenforcer.js
+++ b/backend/apps/kloudust/lib/roleenforcer.js
@@ -55,7 +55,7 @@ exports.checkAccess = function(access_for, user_role=KLOUD_CONSTANTS.env.role) {
 
 exports.isSetupMode = async _ => ((await dbAbstractor.getUserCount()) == 0) && KLOUD_CONSTANTS.env._setup_mode;
 
-exports.canBeSetupMode = async _ => (await dbAbstractor.getUserCount() == 0);
+exports.canBeSetupMode = async _ => (await dbAbstractor.getUserCount() === 0);
 
 exports.isCloudAdminLoggedIn = _ => KLOUD_CONSTANTS.env.role == KLOUD_CONSTANTS.ROLES.CLOUD_ADMIN;
 


### PR DESCRIPTION
canBeSetupMode incorrectly returns true even when a cloud admin already exists due to 
```js
false == 0
```
 coercion
