### PR TITLE
Minor fix, in case when role is undefined

### DIFF
--- a/backend/apps/kloudust/lib/roleenforcer.js
+++ b/backend/apps/kloudust/lib/roleenforcer.js
@@ -25,7 +25,7 @@ exports.ACTIONS = Object.freeze({
  * @param {Symbol} access_for The action for which access is needed, should be one of roleenforcer.ACTIONS
  * @param {string} user_role The user's role - can be user, admin or cloud admin, as defined in KLOUD_CONSTANTS
  */
-exports.checkAccess = function(access_for, user_role=KLOUD_CONSTANTS.env.role()) {
+exports.checkAccess = function(access_for, user_role=KLOUD_CONSTANTS.env?.role?.()) {
     const actions = exports.ACTIONS, roles = KLOUD_CONSTANTS.ROLES;
 
     if (access_for == actions.edit_cloud_resource && user_role == roles.CLOUD_ADMIN) return true;


### PR DESCRIPTION
This happens when the cloud is already initialized and a second user tries to login and the canBeSetupMode is called which does a DB check which does a roleenforcer check (if usercount is not 0) and because the _setupKloudustEnvironment is called after the check, this was throwing an error before the fix.