### PR TITLE
Fix for roleenforcer canBeSetupMode check that happen before env init

### DIFF
--- a/backend/apps/kloudust/kloudust.js
+++ b/backend/apps/kloudust/kloudust.js
@@ -154,11 +154,11 @@ function _setupKloudustEnvironment(asyncContextStorage, name, id, org, role, pro
     const store = asyncContextStorage.getStore();
     store.username = name; store.id = id; store.org = org; store.role = role; store.project = project; 
 
-    KLOUD_CONSTANTS.env.username = _ => asyncContextStorage.getStore().username;
-    KLOUD_CONSTANTS.env.userid = _ => asyncContextStorage.getStore().id.toLocaleLowerCase();
-    KLOUD_CONSTANTS.env.org = _ => asyncContextStorage.getStore().org;
-    KLOUD_CONSTANTS.env.role = _ => asyncContextStorage.getStore().role;
-    KLOUD_CONSTANTS.env.prj = _ => asyncContextStorage.getStore().project;
+    KLOUD_CONSTANTS.env.username = _ => asyncContextStorage.getStore()?.username;
+    KLOUD_CONSTANTS.env.userid = _ => asyncContextStorage.getStore()?.id.toLocaleLowerCase();
+    KLOUD_CONSTANTS.env.org = _ => asyncContextStorage.getStore()?.org;
+    KLOUD_CONSTANTS.env.role = _ => asyncContextStorage.getStore()?.role;
+    KLOUD_CONSTANTS.env.prj = _ => asyncContextStorage.getStore()?.project;
 }
 
 function _createConsoleHandler(consoleStreamHandler) {


### PR DESCRIPTION
This happens when the cloud is already initialized and a second user tries to login and the canBeSetupMode is called which does a DB check which does a roleenforcer check (if usercount is not 0) and because the _setupKloudustEnvironment is called after the check, this was throwing an error before the fix.