### PR TITLE
Apply and Remove Firewall Rulesets

### DIFF
--- a/backend/apps/kloudust/lib/cmd/applyFirewallRuleset.js
+++ b/backend/apps/kloudust/lib/cmd/applyFirewallRuleset.js
@@ -1,0 +1,82 @@
+/**
+ * applyFirewallRuleset.js – applies a firewall ruleset to a vm's vnet
+ *
+ * Params:
+ *  0 - vm_name
+ *  1 - ruleset_name
+ *  2 - vnet_name
+ *
+ * (C) 2026 TekMonks. All rights reserved.
+ * License: See enclosed LICENSE file.
+ */
+
+const roleman = require(`${KLOUD_CONSTANTS.LIBDIR}/roleenforcer.js`);
+const dbAbstractor = require(`${KLOUD_CONSTANTS.LIBDIR}/dbAbstractor.js`);
+const CMD_CONSTANTS = require(`${KLOUD_CONSTANTS.LIBDIR}/cmd/cmdconstants.js`);
+const {xforge} = require(`${KLOUD_CONSTANTS.LIBDIR}/3p/xforge/xforge`);
+const createFirewallRuleset = require(`${KLOUD_CONSTANTS.LIBDIR}/cmd/createFirewallRuleset.js`);
+const createVM = require(`${KLOUD_CONSTANTS.LIBDIR}/cmd/createVM.js`);
+const createVnet = require(`${KLOUD_CONSTANTS.LIBDIR}/cmd/createVnet.js`);
+
+module.exports.exec = async function(params) {
+
+    if (!roleman.checkAccess(roleman.ACTIONS.edit_project_resource)) { params.consoleHandlers.LOGUNAUTH(); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const [vm_name_raw, ruleset_name_raw, vnet_name_raw_in] = params;
+    if (!vm_name_raw || !ruleset_name_raw) { params.consoleHandlers.LOGERROR("Missing VM name or ruleset name"); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const ip_type = vnet_name_raw_in === "" ? "public" : "private"; // if we do not receive an explicit vnet name, we assume the user wants to apply the ruleset to the public IP of the VM, if it has one
+    const vm_name = createVM.resolveVMName(vm_name_raw);
+    const ruleset_name = createFirewallRuleset.resolveRulesetName(ruleset_name_raw);
+    const vnet_name_raw = vnet_name_raw_in || createVnet.getInternetBackboneVnet();
+    const vnet_name = createVnet.resolveVnetName(vnet_name_raw);
+    if (!vm_name || !ruleset_name || !vnet_name) { params.consoleHandlers.LOGERROR("Invalid VM, ruleset or Vnet name"); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const vm = await dbAbstractor.getVM(vm_name);
+    if (!vm) { params.consoleHandlers.LOGERROR("Bad VM name or VM not found"); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const vnet = await dbAbstractor.getVnet(vnet_name);
+    if (!vnet) { params.consoleHandlers.LOGERROR("Bad Vnet name or Vnet not found"); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const ruleset = await dbAbstractor.getFirewallRuleset(ruleset_name);
+    if (!ruleset) { params.consoleHandlers.LOGERROR("Bad ruleset name or ruleset not found"); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const vm_vnet_rulesets = await dbAbstractor.getVMVnetFirewall(vm.name, vnet.name);
+    if (vm_vnet_rulesets.includes(ruleset.id)) { params.consoleHandlers.LOGERROR(`Vnet ${vnet.name} of VM ${vm.name} already has firewall ${ruleset.name} applied to it!`); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const public_ip = vm.ips.trim();
+    if (!public_ip && ip_type === "public") { params.consoleHandlers.LOGERROR("VM has no public IP"); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const public_ip_host = ip_type === "public" ? await dbAbstractor.getHostEntry(await dbAbstractor.getHostForIP(public_ip)) : null;
+    if (ip_type === "public" && !public_ip_host) { params.consoleHandlers.LOGERROR("Host info not found for VM public IP"); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const vm_host = ip_type === "private" ? await dbAbstractor.getHostEntry(vm.hostname) : null;
+    if (ip_type === "private" && !vm_host) { params.consoleHandlers.LOGERROR("Bad hostname for the VM or host not found"); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const rules_json = JSON.stringify(JSON.stringify(JSON.parse(ruleset.rules_json).reverse()));
+
+    const [command, args, host] =
+        ip_type === "public"
+            ? ["applyFirewallRulesetPublic", [rules_json, public_ip, vm.name, ruleset.name], public_ip_host]
+            : ["applyFirewallRulesetPrivate", [rules_json, vnet.vnetnum, vm.name, ruleset.name], vm_host];
+
+    const xforgeArgsApplyRuleset = { 
+        colors: KLOUD_CONSTANTS.COLORED_OUT, 
+        file: `${KLOUD_CONSTANTS.LIBDIR}/3p/xforge/samples/remoteCmd.xf.js`, 
+        console: params.consoleHandlers,
+        other: [host.hostaddress, host.rootid, host.rootpw, host.hostkey, host.port, 
+            `${KLOUD_CONSTANTS.LIBDIR}/cmd/scripts/${command}.sh`, ...args] 
+        };
+    
+    const apply_result = await xforge(xforgeArgsApplyRuleset);
+
+    if (!apply_result.result) { params.consoleHandlers.LOGERROR(`Firewall ruleset ${ruleset.name} could not be applied to Vnet ${vnet.name} of VM ${vm_name_raw}`); return {...apply_result, ...CMD_CONSTANTS.FALSE_RESULT()}; }
+
+    const insertResult = await dbAbstractor.addVMVnetFirewall(vm.name, vnet.name, ruleset.name);
+    if (!insertResult) { params.consoleHandlers.LOGERROR("DB insert failed!"); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    params.consoleHandlers.LOGINFO(`Firewall ruleset ${ruleset.name} was applied to Vnet ${vnet.name} of VM ${vm_name_raw}`);
+    return {...apply_result, ...CMD_CONSTANTS.TRUE_RESULT()};
+};
+
+exports.resolveRulesetName = ruleset_name_raw => ruleset_name_raw ? `${ruleset_name_raw}_${KLOUD_CONSTANTS.env.org}_${KLOUD_CONSTANTS.env.prj}`.toLowerCase().replace(/\s/g,"_") : null;

--- a/backend/apps/kloudust/lib/cmd/removeFirewallRuleset.js
+++ b/backend/apps/kloudust/lib/cmd/removeFirewallRuleset.js
@@ -1,0 +1,75 @@
+/**
+ * applyFirewallRuleset.js – applies a firewall ruleset to a vm's vnet
+ *
+ * Params:
+ *  0 - vm_name
+ *  1 - ruleset_name
+ *  2 - vnet_name
+ *
+ * (C) 2026 TekMonks. All rights reserved.
+ * License: See enclosed LICENSE file.
+ */
+
+const roleman = require(`${KLOUD_CONSTANTS.LIBDIR}/roleenforcer.js`);
+const dbAbstractor = require(`${KLOUD_CONSTANTS.LIBDIR}/dbAbstractor.js`);
+const CMD_CONSTANTS = require(`${KLOUD_CONSTANTS.LIBDIR}/cmd/cmdconstants.js`);
+const {xforge} = require(`${KLOUD_CONSTANTS.LIBDIR}/3p/xforge/xforge`);
+const createFirewallRuleset = require(`${KLOUD_CONSTANTS.LIBDIR}/cmd/createFirewallRuleset.js`);
+const createVM = require(`${KLOUD_CONSTANTS.LIBDIR}/cmd/createVM.js`);
+const createVnet = require(`${KLOUD_CONSTANTS.LIBDIR}/cmd/createVnet.js`);
+
+module.exports.exec = async function(params) {
+    if (!roleman.checkAccess(roleman.ACTIONS.edit_project_resource)) { params.consoleHandlers.LOGUNAUTH(); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const [vm_name_raw, ruleset_name_raw, vnet_name_raw_in] = params;
+    if (!vm_name_raw || !ruleset_name_raw) { params.consoleHandlers.LOGERROR("Missing VM name or ruleset name"); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const ip_type = vnet_name_raw_in === "" ? "public" : "private";  // if we do not receive an explicit vnet name, we assume the user wants to apply the ruleset to the public IP of the VM, if it has one
+    const vm_name = createVM.resolveVMName(vm_name_raw);
+    const ruleset_name = createFirewallRuleset.resolveRulesetName(ruleset_name_raw);
+    const vnet_name_raw = vnet_name_raw_in || createVnet.getInternetBackboneVnet();
+    const vnet_name = createVnet.resolveVnetName(vnet_name_raw);
+    if (!vm_name || !ruleset_name || !vnet_name) { params.consoleHandlers.LOGERROR("Invalid VM, ruleset or Vnet name"); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const vm = await dbAbstractor.getVM(vm_name);
+    if (!vm) { params.consoleHandlers.LOGERROR("Bad VM name or VM not found"); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const vnet = await dbAbstractor.getVnet(vnet_name);
+    if (!vnet) { params.consoleHandlers.LOGERROR("Bad Vnet name or Vnet not found"); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const ruleset = await dbAbstractor.getFirewallRuleset(ruleset_name);
+    if (!ruleset) { params.consoleHandlers.LOGERROR("Bad ruleset name or ruleset not found"); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const vm_vnet_rulesets = await dbAbstractor.getVMVnetFirewall(vm.name, vnet.name);
+    if (!vm_vnet_rulesets.includes(ruleset.id)) { params.consoleHandlers.LOGERROR(`Vnet ${vnet.name} of VM ${vm.name} does not have firewall ${ruleset.name} applied to it!`); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const public_ip = vm.ips.trim();
+    if (!public_ip && ip_type === "public") { params.consoleHandlers.LOGERROR("VM has no public IP"); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const public_ip_host = ip_type === "public" ? await dbAbstractor.getHostEntry(await dbAbstractor.getHostForIP(public_ip)) : null;
+    if (ip_type === "public" && !public_ip_host) { params.consoleHandlers.LOGERROR("Host info not found for VM public IP"); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const vm_host = ip_type === "private" ? await dbAbstractor.getHostEntry(vm.hostname) : null;
+    if (ip_type === "private" && !vm_host) { params.consoleHandlers.LOGERROR("Bad hostname for the VM or host not found"); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    const [args, host] = ip_type === "public" ? [["public", public_ip, vm.name, ruleset.name], public_ip_host] : [["private", vnet.vnetnum, vm.name, ruleset.name], vm_host];
+
+    const xforgeArgsRemoveRuleset = { 
+        colors: KLOUD_CONSTANTS.COLORED_OUT, 
+        file: `${KLOUD_CONSTANTS.LIBDIR}/3p/xforge/samples/remoteCmd.xf.js`, 
+        console: params.consoleHandlers,
+        other: [host.hostaddress, host.rootid, host.rootpw, host.hostkey, host.port, 
+            `${KLOUD_CONSTANTS.LIBDIR}/cmd/scripts/removeFirewallRuleset.sh`, ...args] 
+        };
+    
+    const remove_result = await xforge(xforgeArgsRemoveRuleset);
+    if (!remove_result.result) { params.consoleHandlers.LOGERROR(`Firewall ruleset ${ruleset.name} could not be removed from ${vnet.name} of VM ${vm_name_raw}`); return {...apply_result, ...CMD_CONSTANTS.FALSE_RESULT()}; }
+    
+    const deleteResult = await dbAbstractor.removeVMVnetFirewall(vm.name, vnet.name, ruleset.name);
+    if (!deleteResult) { params.consoleHandlers.LOGERROR("DB delete failed!"); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    params.consoleHandlers.LOGINFO(`Firewall ruleset ${ruleset.name} was removed from Vnet ${vnet.name} of VM ${vm_name_raw}`);
+    return {...remove_result, ...CMD_CONSTANTS.TRUE_RESULT()};
+};
+
+exports.resolveRulesetName = ruleset_name_raw => ruleset_name_raw ? `${ruleset_name_raw}_${KLOUD_CONSTANTS.env.org}_${KLOUD_CONSTANTS.env.prj}`.toLowerCase().replace(/\s/g,"_") : null;

--- a/backend/apps/kloudust/lib/cmd/scripts/applyFirewallRulesetPrivate.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/applyFirewallRulesetPrivate.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+#########################################################################################################
+# Applies firewall rules for a private IP
+#
+# Params:
+#  1 - Firewall ruleset JSON
+#  2 - VNet ID for getting mac address of vm interface and for unique comment to grep handles later
+#  3 - VM Name for unique comment to grep handles later
+#  4 - Ruleset name for unique comment to grep handles later
+#
+# (C) 2026 TekMonks. All rights reserved.
+#########################################################################################################
+
+RULES_JSON="{1}"
+VNET_ID="{2}"
+VM_NAME="{3}"
+RULESET_NAME="{4}"
+BR_NAME="kd${VNET_ID}_br"
+
+echoerr() { echo "$@" 1>&2; }
+
+function exitFailed() {
+    echo Failed
+    exit 1
+}
+
+MAC_ADDRESS=$(virsh dumpxml "$VM_NAME" | xmllint --xpath "string(//interface[@type='bridge'][source/@bridge='$BR_NAME']/mac/@address)" -)
+if [ -z "$MAC_ADDRESS" ]; then
+    echoerr "Could not locate MAC for the VM $VM_NAME attached to VNet $VNET_ID or already detached, skipping."
+    exitFailed
+else
+    echo "Found MAC $MAC_ADDRESS for VM attachment to the VNet. Proceeding with firewall setup."
+fi
+
+if ! modprobe br_netfilter; then exitFailed; fi
+if ! echo "br_netfilter" | sudo tee /etc/modules-load.d/br_netfilter.conf >/dev/null; then exitFailed; fi
+
+if ! sudo nft add table bridge "${BR_NAME}_filter" 2>/dev/null; then true; fi
+if ! sudo nft add chain bridge "${BR_NAME}_filter" forward '{ type filter hook forward priority 0; policy accept; }'; then exitFailed; fi
+if ! sudo nft add rule bridge "${BR_NAME}_filter" forward ether saddr "$MAC_ADDRESS" ether type arp counter accept comment \"$RULESET_NAME-$VM_NAME-$VNET_ID\"; then exitFailed; fi
+if ! sudo nft add rule bridge "${BR_NAME}_filter" forward  ether daddr "$MAC_ADDRESS" ether type arp counter accept comment \"$RULESET_NAME-$VM_NAME-$VNET_ID\"; then exitFailed; fi
+if ! sudo nft add rule bridge "${BR_NAME}_filter" forward ether daddr "$MAC_ADDRESS" ct state established,related counter accept comment \"$RULESET_NAME-$VM_NAME-$VNET_ID\"; then exitFailed; fi
+
+echo "$RULES_JSON" | jq -c '.[]' | while read -r rule; do
+    DIRECTION=$(echo "$rule" | jq -r '.direction')
+    ALLOW=$(echo "$rule" | jq -r '.allow')
+    PROTOCOL=$(echo "$rule" | jq -r '.protocol')
+    PORT=$(echo "$rule" | jq -r '.port')
+    IP=$(echo "$rule" | jq -r '.ip')
+
+    if [ "$ALLOW" = "true" ]; then
+        ACTION="accept"
+    else
+        ACTION="drop"
+    fi
+
+    if [ "$DIRECTION" = "in" ]; then
+        MAC_MATCH="ether daddr $MAC_ADDRESS"
+    else
+        MAC_MATCH="ether saddr $MAC_ADDRESS"
+    fi
+
+    IP_MATCH=""
+    if [ "$IP" != "*" ] && [ "$IP" != "null" ]; then
+        if [ "$DIRECTION" = "in" ]; then
+            IP_MATCH="ip saddr $IP"
+        else
+            IP_MATCH="ip daddr $IP"
+        fi
+    fi
+
+    PROTO_MATCH=""
+    PORT_MATCH=""
+
+    if [ "$PROTOCOL" = "tcp" ] || [ "$PROTOCOL" = "udp" ]; then
+        if [ -n "$PORT" ] && [ "$PORT" != "null" ]; then
+            PORT_MATCH="$PROTOCOL dport $PORT"
+        fi
+    fi
+
+    if [ "$PROTOCOL" = "all" ]; then
+        PROTO_MATCH=""
+        PORT_MATCH=""
+    fi
+
+    if ! sudo nft add rule bridge "${BR_NAME}_filter" forward \
+        $MAC_MATCH $IP_MATCH $PROTO_MATCH $PORT_MATCH counter $ACTION comment \"$RULESET_NAME-$VM_NAME-$VNET_ID\"; then
+        exitFailed
+    fi
+done
+
+
+
+echo "MAC-based firewall rules applied!"
+exit 0

--- a/backend/apps/kloudust/lib/cmd/scripts/applyFirewallRulesetPublic.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/applyFirewallRulesetPublic.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+#########################################################################################################
+# Applies internet firewall rules for a routed public IP
+#
+# Params:
+#  1 - Firewall ruleset JSON
+#  2 - Public IP
+#  3 - VM Name for unique comment to grep handles later
+#  4 - Ruleset name for unique comment to grep handles later
+#
+# (C) 2026 TekMonks. All rights reserved.
+#########################################################################################################
+
+RULES_JSON="{1}"
+PUBLIC_IP="{2}"
+VM_NAME="{3}"
+RULESET_NAME="{4}"
+
+IP_ADDRESS_DASHED=$(echo "$PUBLIC_IP" | tr '.' '_')
+
+echoerr() { echo "$@" 1>&2; }
+
+function exitFailed() {
+    echo Failed
+    exit 1
+}
+
+if ! sudo nft add table inet "ip_${IP_ADDRESS_DASHED}_filter"; then exitFailed; fi
+if ! sudo nft add chain inet "ip_${IP_ADDRESS_DASHED}_filter" forward '{ type filter hook forward priority 0; policy accept; }'; then exitFailed; fi
+if ! sudo nft add rule inet "ip_${IP_ADDRESS_DASHED}_filter" forward ip daddr "$PUBLIC_IP" ct state established,related counter accept comment \"$RULESET_NAME-$VM_NAME-$IP_ADDRESS_DASHED\"; then exitFailed; fi
+
+echo "$RULES_JSON" | jq -c '.[]' | while read -r rule; do
+    DIRECTION=$(echo "$rule" | jq -r '.direction')
+    ALLOW=$(echo "$rule" | jq -r '.allow')
+    PROTOCOL=$(echo "$rule" | jq -r '.protocol')
+    PORT=$(echo "$rule" | jq -r '.port')
+    IP=$(echo "$rule" | jq -r '.ip')
+
+    if [ "$ALLOW" = "true" ]; then
+        ACTION="accept"
+    else
+        ACTION="drop"
+    fi
+
+    if [ "$DIRECTION" = "in" ]; then
+        BASE_MATCH="ip daddr $PUBLIC_IP"
+
+        if [ "$IP" != "*" ] && [ "$IP" != "null" ]; then
+            IP_MATCH="$BASE_MATCH ip saddr $IP"
+        else
+            IP_MATCH="$BASE_MATCH"
+        fi
+    else
+        BASE_MATCH="ip saddr $PUBLIC_IP"
+
+        if [ "$IP" != "*" ] && [ "$IP" != "null" ]; then
+            IP_MATCH="$BASE_MATCH ip daddr $IP"
+        else
+            IP_MATCH="$BASE_MATCH"
+        fi
+    fi
+
+    PORT_MATCH=""
+
+    if [ "$PROTOCOL" = "tcp" ] || [ "$PROTOCOL" = "udp" ]; then
+        if [ -n "$PORT" ] && [ "$PORT" != "null" ]; then
+            PORT_MATCH="$PROTOCOL dport $PORT"
+        fi
+    fi
+
+    if [ "$PROTOCOL" = "all" ]; then
+        PORT_MATCH=""
+    fi
+
+    if ! sudo nft add rule inet "ip_${IP_ADDRESS_DASHED}_filter" forward \
+        $IP_MATCH $PORT_MATCH counter $ACTION comment \"$RULESET_NAME-$VM_NAME-$IP_ADDRESS_DASHED\"; then
+        exitFailed
+    fi
+done
+
+
+
+echo "IP-based firewall rules applied!"
+exit 0

--- a/backend/apps/kloudust/lib/cmd/scripts/removeFirewallRuleset.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/removeFirewallRuleset.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+#########################################################################################################
+# Removes firewall rules for a VM (private or public)
+#
+# Usage:
+#   private <vnet_id> <vm_name> <ruleset_name>
+#   public  <public_ip> <vm_name> <ruleset_name>
+#
+# (C) 2026 TekMonks. All rights reserved.
+#########################################################################################################
+
+MODE="{1}"
+ARG1="{2}"
+VM_NAME="{3}"
+RULESET_NAME="{4}"
+
+echoerr() { echo "$@" 1>&2; }
+
+exitFailed() {
+    echo Failed
+    exit 1
+}
+
+if [ -z "$MODE" ] || [ -z "$ARG1" ] || [ -z "$VM_NAME" ] || [ -z "$RULESET_NAME" ]; then
+    echoerr "Invalid parameters."
+    exitFailed
+fi
+
+case "$MODE" in
+    private)
+        VNET_ID="$ARG1"
+        FAMILY="bridge"
+        TABLE="kd${VNET_ID}_br_filter"
+        COMMENT_SUFFIX="${VNET_ID}"
+        ;;
+    public)
+        PUBLIC_IP="$ARG1"
+        IP_DASHED=$(echo "$PUBLIC_IP" | tr '.' '_')
+        FAMILY="inet"
+        TABLE="ip_${IP_DASHED}_filter"
+        COMMENT_SUFFIX="${IP_DASHED}"
+        ;;
+    *)
+        echoerr "Invalid mode. Use 'private' or 'public'."
+        exitFailed
+        ;;
+esac
+
+COMMENT_STRING="${RULESET_NAME}-${VM_NAME}-${COMMENT_SUFFIX}"
+
+# Ensure table exists
+if ! sudo nft list table "$FAMILY" "$TABLE" >/dev/null 2>&1; then
+    echoerr "Table ${TABLE} does not exist. Nothing to remove."
+    exitFailed
+fi
+
+# Fetch rule handles
+RULES_TO_DELETE=$(sudo nft --handle list chain "$FAMILY" "$TABLE" forward | grep -F "comment \"${COMMENT_STRING}\"" | awk '/handle/ {print $NF}')
+
+if [ -z "$RULES_TO_DELETE" ]; then
+    echo "No rules found for ${RULESET_NAME}-${VM_NAME}. Nothing to remove."
+    exit 0
+fi
+
+# Delete rules
+for HANDLE in $RULES_TO_DELETE; do
+    if ! sudo nft delete rule "$FAMILY" "$TABLE" forward handle "$HANDLE"; then
+        echoerr "Failed to delete rule handle $HANDLE"
+        exitFailed
+    fi
+done
+
+echo "Removed firewall rules for VM ${VM_NAME} (ruleset: ${RULESET_NAME})!"
+exit 0


### PR DESCRIPTION
This pull request adds support for applying and removing a firewall ruleset on a VM.

- Public IP firewalling creates rules in the inet table on the host where the public IP terminates, these rules are ip based.
- Private IP firewalling creates rules in the bridge table on the VM host, these rules are ethernet address based.

Ruleset removal works by adding a unique comment to each rule during apply. When removing a ruleset, the system searches for rules with that comment, extracts their handles, and deletes them.