### PR TITLE
Delete VM Cleanup

### DIFF
--- a/backend/apps/kloudust/lib/cmd/deleteVM.js
+++ b/backend/apps/kloudust/lib/cmd/deleteVM.js
@@ -17,6 +17,11 @@ const dbAbstractor = require(`${KLOUD_CONSTANTS.LIBDIR}/dbAbstractor.js`);
 const deleteVMVnet = require(`${KLOUD_CONSTANTS.LIBDIR}/cmd/deleteVMVnet.js`);
 const unassignIPToVM = require(`${KLOUD_CONSTANTS.LIBDIR}/cmd/unassignIPToVM.js`);
 const CMD_CONSTANTS = require(`${KLOUD_CONSTANTS.LIBDIR}/cmd/cmdconstants.js`);
+const getVMVnets = require(`${KLOUD_CONSTANTS.LIBDIR}/cmd/getVMVnets.js`);
+const vnet = require(`${KLOUD_CONSTANTS.LIBDIR}/vnet.js`);
+const createVnet = require(`${KLOUD_CONSTANTS.LIBDIR}/cmd/createVnet.js`);
+const removeFirewallRuleset = require(`${KLOUD_CONSTANTS.LIBDIR}/cmd/removeFirewallRuleset.js`);
+const createFirewallRuleset = require(`${KLOUD_CONSTANTS.LIBDIR}/cmd/createFirewallRuleset.js`);
 
 /**
  * Deletes the given VM
@@ -29,6 +34,38 @@ module.exports.exec = async function(params) {
     const vm = await dbAbstractor.getVM(vm_name);
     if (!vm) {params.consoleHandlers.LOGERROR("Bad VM name or VM not found"); return CMD_CONSTANTS.FALSE_RESULT();}
     
+    const getVMVnetsParams = [vm.name_raw]; getVMVnetsParams.consoleHandlers = params.consoleHandlers;
+    const vmVnets = await getVMVnets.exec(getVMVnetsParams);
+
+    for (const vmVnet of vmVnets.vnets) {
+        const vnetName = await vnet.resolveVnetName(vmVnet);
+        const vmVnetFirewall = await dbAbstractor.getVMVnetFirewall(vm.name, vnetName);
+        if(vmVnetFirewall.length !== 0){
+            for (const vmvnetfw of vmVnetFirewall) {
+                const ruleset = await dbAbstractor.getFirewallRulesetById(vmvnetfw);
+                const removeFirewallRulesetParams = [vm.name_raw, createFirewallRuleset.unresolveRulesetName(ruleset.name), vmVnet]; removeFirewallRulesetParams.consoleHandlers = params.consoleHandlers;
+                const remove_result = await removeFirewallRuleset.exec(removeFirewallRulesetParams);
+                if (!remove_result.result) { params.consoleHandlers.LOGERROR(`Firewall ruleset ${ruleset.name} could not be removed from ${vnetName} of VM ${vm_name_raw}`); return {...remove_result, ...CMD_CONSTANTS.FALSE_RESULT()}; }                
+            }
+        }
+    }
+
+    const removeRelationshipsResult = await dbAbstractor.removeAllVMVnetIPRelationships(vm.name);
+    if (!removeRelationshipsResult) { params.consoleHandlers.LOGERROR("DB failed to remove all VM-Vnet-IP relationships for the VM"); return CMD_CONSTANTS.FALSE_RESULT(); }
+
+    if(vm.ips.trim() !== ""){
+        const vnetName = await vnet.resolveVnetName(createVnet.getInternetBackboneVnet());
+        const vmVnetFirewall = await dbAbstractor.getVMVnetFirewall(vm.name, vnetName);
+            if(vmVnetFirewall.length !== 0){
+            for (const vmvnetfw of vmVnetFirewall) {
+                const ruleset = await dbAbstractor.getFirewallRulesetById(vmvnetfw);
+                const removeFirewallRulesetParams = [vm.name_raw, createFirewallRuleset.unresolveRulesetName(ruleset.name),""]; removeFirewallRulesetParams.consoleHandlers = params.consoleHandlers;
+                const remove_result = await removeFirewallRuleset.exec(removeFirewallRulesetParams);
+                if (!remove_result.result) { params.consoleHandlers.LOGERROR(`Firewall ruleset ${ruleset.name} could not be removed from ${vnetName} of VM ${vm_name_raw}`); return {...remove_result, ...CMD_CONSTANTS.FALSE_RESULT()}; }                
+            }
+        }
+    } 
+
     if (vm.ips.trim() !== "") { const allIps = vm.ips.split(",").map(ip => ip.trim()); for (const ip of allIps) { await unassignIPToVM.exec([vm_name_raw, ip]) }}
     
     const hostInfo = await dbAbstractor.getHostEntry(vm.hostname); 

--- a/backend/apps/kloudust/lib/dbAbstractor.js
+++ b/backend/apps/kloudust/lib/dbAbstractor.js
@@ -1049,6 +1049,18 @@ exports.getFirewallRuleset = async function(ruleset, project=KLOUD_CONSTANTS.env
 }
 
 /**
+ * Returns the given ruleset object.
+ * @param {string} name The ruleset ID
+ * @returns The ruleset object, if found, else null.
+ */
+exports.getFirewallRulesetById = async function(id) {
+    if (!roleman.checkAccess(roleman.ACTIONS.lookup_project_resource)) {_logUnauthorized(); return false;}
+    const query = "select * from firewallrulesets where id=? collate nocase";
+    const ruleset_entry = await _db().getQuery(query, [id]);
+    if (ruleset_entry && ruleset_entry.length) return ruleset_entry[0]; else return null;
+}
+
+/**
  * Adds or updates a firewall ruleset in DB
  *
  * @param {string} name Ruleset name
@@ -1186,6 +1198,22 @@ exports.removeVMVnetIP = async function(vm_name, vnet_name, ip, project=KLOUD_CO
     const vnet_id = `${org}_${project}_${vnet_name}`;
 
     const cmd = "delete from relationships where pk1 = ? and pk2 = ? and pk3 = ? and type = ?", params =  [vm_id, vnet_id, ip, 'vmvnetip'];
+    const deleteResult = await _db().runCmd(cmd, params);
+    return deleteResult;
+}
+
+/**
+ * Removes all vmvnetip relationships for the given VM
+ * @param {string} vm_name The VM name
+ * @param {string} project The project, if skipped is auto picked from the environment
+ * @param {string} org The org, if skipped is auto picked from the environment
+ * @returns true on success or false on failure
+ */
+exports.removeAllVMVnetIPRelationships = async function(vm_name, project=KLOUD_CONSTANTS.env.prj(), org=KLOUD_CONSTANTS.env.org()) {
+    if (!roleman.checkAccess(roleman.ACTIONS.edit_project_resource)) {_logUnauthorized(); return false;}
+    
+    const vm_id = `${org}_${project}_${vm_name}`;
+    const cmd = "delete from relationships where pk1 = ? and type = ?", params =  [vm_id, 'vmvnetip'];
     const deleteResult = await _db().runCmd(cmd, params);
     return deleteResult;
 }


### PR DESCRIPTION
When the vm gets deleted its private ips and firewall rules don't get removed
removing the private ip relationship is simple because it doesn't impact the other vms but we must remove all firewall rules before deleting the vms as same ip could be assigned to other vms or there could be an ethernet conflict(potentially)