### PR TITLE
added the copy feature for VM details

### DIFF
--- a/frontend/apps/kloudust/commands/forms/vms.form.json
+++ b/frontend/apps/kloudust/commands/forms/vms.form.json
@@ -121,6 +121,8 @@
 
     "i18nPrefix": "VMS",
 
+    "enable_copy": true,
+
     "onclickrow_html": [
         "<style>div#onclick_html {background-color: #F8F8F8; width: auto;} div#close{display: none !important}</style>",
         "<style>div#onclickrow_html {height: fit-content;} div#body{background-color: #F8F8F8 !important}</style>",

--- a/frontend/apps/kloudust/components/table-list/table-list.html
+++ b/frontend/apps/kloudust/components/table-list/table-list.html
@@ -121,6 +121,41 @@ tbody tr:hover {
     background-color: #BC5205;
     color: #f3f3f3;
 }
+
+tbody.copy-enabled td {
+        cursor: copy;
+        position: relative;
+}
+
+tbody.copy-enabled td:hover::after {
+        content: 'Click to copy';
+        position: absolute;
+        top: -1.8em;
+        left: 0;
+        background: #333;
+        color: #fff;
+        font-size: 0.75em;
+        padding: 2px 6px;
+        border-radius: 3px;
+        white-space: nowrap;
+        pointer-events: none;
+        z-index: 5;
+}
+
+td[data-copied="true"]::after {
+        content: "Copied";
+        position: absolute;
+        left: 0;
+        top: -1.8em;
+        background: #333;
+        color: #fff;
+        padding: 2px 6px;
+        font-size: 0.75em;
+        border-radius: 3px;
+        white-space: nowrap;
+        z-index: 5;
+        pointer-events: none;
+} 
 </style>
 {{#style}}<style>{{{.}}}</style>{{/style}}
 
@@ -135,7 +170,29 @@ tbody tr:hover {
     </tr>
     </thead>
 
-    <tbody>
+    <tbody
+       {{#enable_copy}}
+            class="copy-enabled"
+            onclick="
+                let el; 
+                if (event.target && event.target.nodeType === 3) el = event.target.parentElement
+                else el = event.target;
+                let td = null;
+                if (el && el.closest) td = el.closest('td');
+
+                if (td) {
+                    const text = (td.textContent || '').trim();
+                    if (text) {
+                        $$.copyTextToClipboard(text);
+                        td.dataset.copied = 'true';
+                        clearTimeout(td.__t);
+                        td.__t = setTimeout(() => delete td.dataset.copied, 1200);
+                    }
+                }
+            "
+        {{/enable_copy}}
+    >
+
     {{#rows}}
     <tr onclick="monkshu_env.components['table-list'].rowClicked(event, '{{{rowdata_json_base64}}}')">
     {{#.}}<td>{{.}}</td>{{/.}}


### PR DESCRIPTION
### Feature: Click-to-Copy for Virtual Machine Details

Implemented a **click-to-copy** feature for Virtual Machine details to improve usability and quick data access.

#### Changes

* **Each cell is now clickable** and copies its value to the clipboard when clicked.
* Added a **tooltip on hover** displaying *“Click to copy ”* to indicate the functionality to users.
* **IP Address field** is also directly clickable, allowing users to quickly copy the IP address.
* Users can now easily copy any Virtual Machine detail (e.g., IP address, cores, memory, etc.) with a single click.
<img width="1589" height="180" alt="Screenshot from 2026-03-10 16-59-44" src="https://github.com/user-attachments/assets/432c5a70-3a42-4bf2-a406-731258fcf8b3" />
<img width="1589" height="180" alt="Screenshot from 2026-03-10 16-59-55" src="https://github.com/user-attachments/assets/0d6c1a89-79a5-4de4-9d35-526a40699726" />


This enhancement makes it faster and more convenient to copy VM information without manually selecting text.
