### PR TITLE
Wrong variable name causes IP assignment to always fail on Windows VMs

### DIFF
--- a/backend/apps/kloudust/lib/cmd/scripts/assignVMIPViaVnet.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/assignVMIPViaVnet.sh
@@ -81,7 +81,7 @@ JSON_PAYLOAD_WINDOWS=$(jq -n --arg script "$WINDOWS_PS_SCRIPT" \
         '{execute: "guest-exec", arguments: {path: "powershell", arg: ["-Command", $script], "capture-output": true}}')
 
 
-if [ -z "$IS_WINDOWS_VM" ]; then
+if [ -z "$IS_WINDOWS" ]; then
     # This is for Linux, uses netplan
     echo Using this Netplan script for Linux VM: $LINUX_NETPLAN_SCRIPT
     if ! PID=$(virsh qemu-agent-command $VM_NAME $JSON_PAYLOAD_LINUX | jq -r '.return.pid'); then exitFailed; fi


### PR DESCRIPTION
In assignVMIPViaVnet.sh, the script sets IS_WINDOWS=true when a Windows VM is detected, but later checks IS_WINDOWS_VM, which is never defined.
As a result, the condition [ -z "$IS_WINDOWS_VM" ] always evaluates to true, causing all VMs (including Windows) to follow the Linux Netplan path.
This leads to silent IP assignment failures on Windows VMs.

Fix: Replace [ -z "$IS_WINDOWS_VM" ] with [ -z "$IS_WINDOWS" ].