### PR TITLE
Fixed PORT Mismatching

### DIFF
--- a/backend/apps/kloudust/lib/cmd/scripts/applyFirewallRuleset.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/applyFirewallRuleset.sh
@@ -88,7 +88,7 @@ while read -r rule; do
     fi
 
     PORT_MATCH=""
-    if { [ "$PROTOCOL" = "tcp" ] || [ "$PROTOCOL" = "udp" ]; } && [ -n "$PORT" ] && [ "$PORT" != "null" ]; then
+    if { [ "$PROTOCOL" = "tcp" ] || [ "$PROTOCOL" = "udp" ]; } && [ -n "$PORT" ] && [ "$PORT" != "*" ] && [ "$PORT" != "null" ]; then
         PORT_MATCH="$PROTOCOL dport $PORT"
     fi
 


### PR DESCRIPTION
## Change
Earlier, when we were creating a firewall rule where the protocol was TCP or UDP and the port was assigned as * (meaning all ports), then PORT_MATCH="$PROTOCOL dport $PORT" caused an issue because * is not recognized by nftables. As a result, the rule was not being added to the firewall.

To fix this, I added a check for the port value:

If PORT != * then:
PORT_MATCH="$PROTOCOL dport $PORT"

Otherwise:
PORT_MATCH=""