### PR TITLE
Created firewall hook

### DIFF
--- a/backend/apps/kloudust/lib/cmd/addHost.js
+++ b/backend/apps/kloudust/lib/cmd/addHost.js
@@ -45,6 +45,24 @@ module.exports.exec = async function(params) {
 
     const newPassword = nochangepassword.toLowerCase() == "nochange" ? adminpass : cryptoMod.randomBytes(32).toString("hex");
     const agentconfig = xforge_module.getAgentConfig(hostip, adminid, newPassword, newsshport);
+    
+    const hookInstallArgs = {
+        colors: KLOUD_CONSTANTS.COLORED_OUT,
+        console: params.consoleHandlers,
+        file: `${KLOUD_CONSTANTS.THIRD_PARTY_DIR}/xforge/samples/remoteCmd.xf.js`,
+        other: [
+            hostip, adminid, adminpass, hostsshkey, oldsshport,
+            `${KLOUD_CONSTANTS.LIBDIR}/cmd/scripts/firewallHook.sh`,
+            "install"
+        ],
+        agent_config: agentconfig
+    };
+    const hookInstallResults = await xforge_module.xforge(hookInstallArgs);
+    if (hookInstallResults.exitCode != 0) {
+        _showError("Script error in installing the libvirt hook.", hostip, newPassword, adminid, adminpass, oldsshport, newsshport, params.consoleHandlers||KLOUD_CONSTANTS.LOG);
+        return {result: false, out: hookInstallResults.stdout, stdout: hookInstallResults.stdout, stderr: hookInstallResults.stderr, err: hookInstallResults.stderr};
+    }
+
     const xforgeArgs = {
         colors: KLOUD_CONSTANTS.COLORED_OUT, 
         console: params.consoleHandlers,

--- a/backend/apps/kloudust/lib/cmd/scripts/addHost.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/addHost.sh
@@ -115,6 +115,21 @@ if ! sudo lsmod | grep -i kvm; then exitFailed; fi
 if ! sudo systemctl enable --now tuned; then exitFailed; fi
 if ! sudo tuned-adm profile virtual-host; then exitFailed; fi
 
+printf "\n\nAllowing libvirt hook execution in AppArmor\n"
+if [ -f /etc/apparmor.d/usr.sbin.libvirtd ] && command -v apparmor_parser >/dev/null 2>&1; then
+    if ! sudo mkdir -p /etc/apparmor.d/local; then exitFailed; fi
+    if [ ! -f /etc/apparmor.d/local/usr.sbin.libvirtd ]; then
+        if ! sudo tee /etc/apparmor.d/local/usr.sbin.libvirtd > /dev/null <<EOF
+# Site-specific additions and overrides for usr.sbin.libvirtd.
+EOF
+        then exitFailed; fi
+    fi
+    if ! sudo grep -qxF '/kloudust/system/libvirt-hooks/qemu rmix,' /etc/apparmor.d/local/usr.sbin.libvirtd; then
+        if ! printf '/kloudust/system/libvirt-hooks/qemu rmix,\n' | sudo tee -a /etc/apparmor.d/local/usr.sbin.libvirtd > /dev/null; then exitFailed; fi
+    fi
+    if ! sudo apparmor_parser -r /etc/apparmor.d/usr.sbin.libvirtd; then exitFailed; fi
+fi
+
 
 printf "\n\nDisabling libvirt default networking\n"
 sudo virsh net-destroy default &> /dev/null

--- a/backend/apps/kloudust/lib/cmd/scripts/applyFirewallRuleset.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/applyFirewallRuleset.sh
@@ -17,6 +17,7 @@ VNET_ID="{2}"
 VM_NAME="{3}"
 RULESET_NAME="{4}"
 BR_NAME="kd${VNET_ID}_br"
+STATE_DIR="/kloudust/system/firewall-state"
 
 echoerr() { echo "$@" 1>&2; }
 
@@ -34,42 +35,51 @@ else
     echo "Found MAC $MAC_ADDRESS for VM attachment to the VNet. Proceeding with firewall setup."
 fi
 
-FORWARD_CHAIN="kd_$(echo "${RULESET_NAME}_${VM_NAME}_${VNET_ID}" | md5sum | cut -c1-24)" # Unique chain name (<=31 chars limit)
+# Find the vnet interface on the host that corresponds to this VM's MAC
+# Host-side tap interface MAC has fe: prefix replacing the first octet
+HOST_MAC=$(echo "$MAC_ADDRESS" | sed 's/^../fe/')
+VNET_IFACE=$(ip -br link | awk -v mac="$HOST_MAC" 'tolower($3) == tolower(mac) {print $1}')
+if [ -z "$VNET_IFACE" ]; then
+    echoerr "Could not find host vnet interface for MAC $HOST_MAC"
+    exitFailed
+else
+    echo "Found host vnet interface $VNET_IFACE for VM $VM_NAME."
+fi
 
-NFT_FAMILY="bridge"    # Using bridge family
-NFT_TABLE="kdhostfirewall_bridge"
+COMMENT="$RULESET_NAME-$VM_NAME-$VNET_ID"
+EGRESS_CHAIN="kd_$(echo "${RULESET_NAME}_${VM_NAME}_${VNET_ID}_e" | md5sum | cut -c1-24)_e"     # Max chain name length is 31 characters
+INGRESS_CHAIN="kd_$(echo "${RULESET_NAME}_${VM_NAME}_${VNET_ID}_i" | md5sum | cut -c1-24)_i"    # Max chain name length is 31 characters
 
-# Create bridge table if not exists
-if ! sudo nft add table "$NFT_FAMILY" "$NFT_TABLE" 2>/dev/null; then true; fi
+# Recreate cleanly if the same firewall was already present.
+while read -r FAMILY TABLE CHAIN; do
+    if [ -z "$FAMILY" ] || [ -z "$TABLE" ] || [ -z "$CHAIN" ]; then continue; fi
+    sudo nft delete chain "$FAMILY" "$TABLE" "$CHAIN" 2>/dev/null || true
+done < <(sudo nft -j list ruleset | jq -r --arg comment "$COMMENT" '
+  .nftables[] | select(.chain) | .chain |
+  select(.comment == $comment) |
+  "\(.family) \(.table) \(.name)"
+')
 
-# Create single forward chain
-if ! sudo nft add chain "$NFT_FAMILY" "$NFT_TABLE" "$FORWARD_CHAIN" \
-    { type filter hook forward priority 0\; policy accept\; comment \"$RULESET_NAME-$VM_NAME-$VNET_ID\"\; }; then
+# Create netdev table if not exists
+if ! sudo nft add table netdev kdhostfirewall_netdev 2>/dev/null; then true; fi
+
+# Create egress chain (traffic FROM network/internet TO VM)
+if ! sudo nft add chain netdev kdhostfirewall_netdev "$EGRESS_CHAIN" \
+    { type filter hook egress device \"$VNET_IFACE\" priority 0\; policy accept\; comment \"$COMMENT\"\; }; then
     exitFailed
 fi
 
-# Allow ARP in both directions - using MAC address
-if ! sudo nft add rule "$NFT_FAMILY" "$NFT_TABLE" "$FORWARD_CHAIN" \
-    ether type arp ether daddr "$MAC_ADDRESS" accept; then
+# Create ingress chain (traffic FROM VM TO the network/internet)
+if ! sudo nft add chain netdev kdhostfirewall_netdev "$INGRESS_CHAIN" \
+    { type filter hook ingress device \"$VNET_IFACE\" priority 0\; policy accept\; comment \"$COMMENT\"\; }; then
     exitFailed
 fi
 
-if ! sudo nft add rule "$NFT_FAMILY" "$NFT_TABLE" "$FORWARD_CHAIN" \
-    ether type arp ether saddr "$MAC_ADDRESS" accept; then
-    exitFailed
-fi
-
-# Allow packets that are part of established/related connections
-if ! sudo nft add rule "$NFT_FAMILY" "$NFT_TABLE" "$FORWARD_CHAIN" \
-    ct state established,related accept; then
-    exitFailed
-fi
-
-# Drop packets with invalid connection tracking state
-if ! sudo nft add rule "$NFT_FAMILY" "$NFT_TABLE" "$FORWARD_CHAIN" \
-    ct state invalid drop; then
-    exitFailed
-fi
+# Allow ARP in both directions
+if ! sudo nft add rule netdev kdhostfirewall_netdev "$EGRESS_CHAIN" \
+    ether type arp accept comment \"$COMMENT\"; then exitFailed; fi
+if ! sudo nft add rule netdev kdhostfirewall_netdev "$INGRESS_CHAIN" \
+    ether type arp accept comment \"$COMMENT\"; then exitFailed; fi
 
 # Apply rules from JSON
 RULES_FAILED=0
@@ -81,11 +91,7 @@ while read -r rule; do
     IP=$(echo "$rule" | jq -r '.ip')
 
     ACTION="drop"
-    CT_MATCH=""
-    if [ "$ALLOW" = "true" ]; then
-        ACTION="accept"
-        CT_MATCH="ct state new"
-    fi
+    if [ "$ALLOW" = "true" ]; then ACTION="accept"; fi
 
     PORT_MATCH=""
     if { [ "$PROTOCOL" = "tcp" ] || [ "$PROTOCOL" = "udp" ]; } && [ -n "$PORT" ] && [ "$PORT" != "*" ] && [ "$PORT" != "null" ]; then
@@ -94,24 +100,57 @@ while read -r rule; do
         PORT_MATCH="meta l4proto $PROTOCOL"  
     fi
 
-    IP_MATCH="" 
-    # Direction-based MAC + IP filtering
+    IP_MATCH=""
     if [ "$DIRECTION" = "in" ]; then
-        IF_MATCH="ether daddr $MAC_ADDRESS"   # traffic TO vm: dst MAC = VM MAC
-        if [ "$IP" != "*" ] && [ "$IP" != "null" ]; then
-            IP_MATCH="ip saddr $IP"
-        fi
+        # Inbound to VM = egress on vnet, source IP is the remote client
+        CHAIN="$EGRESS_CHAIN"
+        if [ "$IP" != "*" ] && [ "$IP" != "null" ]; then IP_MATCH="ip saddr $IP"; fi
     else
-        IF_MATCH="ether saddr $MAC_ADDRESS"   # traffic FROM vm: src MAC = VM MAC
-        if [ "$IP" != "*" ] && [ "$IP" != "null" ]; then
-            IP_MATCH="ip daddr $IP"
-        fi
+        # Outbound from VM = ingress on vnet, destination IP is the remote target
+        CHAIN="$INGRESS_CHAIN"
+        if [ "$IP" != "*" ] && [ "$IP" != "null" ]; then IP_MATCH="ip daddr $IP"; fi
     fi
 
-    if ! sudo nft add rule "$NFT_FAMILY" "$NFT_TABLE" "$FORWARD_CHAIN" \
-        $IF_MATCH $CT_MATCH $IP_MATCH $PORT_MATCH counter $ACTION \
-        comment \"$RULESET_NAME-$VM_NAME-$VNET_ID\"; then
+    if ! sudo nft add rule netdev kdhostfirewall_netdev "$CHAIN" \
+            $IP_MATCH $PORT_MATCH counter $ACTION comment \"$COMMENT\"; then
         RULES_FAILED=1
         break
     fi
 done < <(echo "$RULES_JSON" | jq -c '.[]')
+
+if [ "$RULES_FAILED" = "1" ]; then 
+    echoerr Rule failed -> "sudo nft add rule netdev kdhostfirewall_netdev \"$CHAIN\" $IP_MATCH $PORT_MATCH counter $ACTION comment \"$COMMENT\""
+    exitFailed
+fi
+
+# Persist
+if ! sudo nft list ruleset | sudo tee /etc/nftables.conf > /dev/null; then exitFailed; fi 
+if ! sudo systemctl enable nftables; then exitFailed; fi
+
+
+# Saves a small local state file under /kloudust/system/firewall-state/
+STATE_ID=$(printf '%s' "${VM_NAME}|${VNET_ID}|${RULESET_NAME}" | md5sum | cut -d" " -f1)
+STATE_FILE="$STATE_DIR/${STATE_ID}.state"
+STATE_TMP="${STATE_FILE}.tmp.$$"
+if sudo mkdir -p "$STATE_DIR"; then
+    if sudo tee "$STATE_TMP" > /dev/null <<EOF
+FW_VM_NAME=$(printf '%q' "$VM_NAME")
+FW_VNET_ID=$(printf '%q' "$VNET_ID")
+FW_RULESET_NAME=$(printf '%q' "$RULESET_NAME")
+FW_RULES_JSON_B64=$(printf '%q' "$(printf '%s' "$RULES_JSON" | base64 | tr -d '\n')")
+EOF
+    then
+        if ! sudo mv "$STATE_TMP" "$STATE_FILE"; then
+            echoerr "Warning: Could not persist firewall reapply state for $VM_NAME"
+        elif ! sudo chmod 600 "$STATE_FILE"; then
+            echoerr "Warning: Could not set permissions on firewall reapply state for $VM_NAME"
+        fi
+    else
+        echoerr "Warning: Could not write firewall reapply state for $VM_NAME"
+    fi
+else
+    echoerr "Warning: Could not create firewall reapply state directory $STATE_DIR"
+fi
+
+echo "Netdev egress+ingress firewall rules applied for $VM_NAME, ruleset $RULESET_NAME and Vnet $VNET_ID"
+exit 0

--- a/backend/apps/kloudust/lib/cmd/scripts/firewallHook.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/firewallHook.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+
+#########################################################################################################
+# Installs and runs the libvirt qemu firewall hook.
+#
+# Usage:
+#   install
+#     Copies this script to /kloudust/system/libvirt-hooks/qemu and symlinks it to /etc/libvirt/hooks/qemu.
+#   <libvirt hook args>
+#     Called by libvirt on VM events. Reapplies firewall state for started/reconnect events.
+#
+# (C) 2026 TekMonks. All rights reserved.
+#########################################################################################################
+
+if [ -z "${FW_HOOK_BOOTSTRAPPED:-}" ] && [ $# -eq 0 ] && [ -p /dev/stdin ]; then
+    FW_HOOK_TEMPFILE="$(mktemp /tmp/firewallHook.XXXXXX)"
+    export FW_HOOK_TEMPFILE
+    cat > "$FW_HOOK_TEMPFILE"
+    FW_HOOK_BOOTSTRAPPED=1 exec /bin/bash "$FW_HOOK_TEMPFILE"
+fi
+
+if [ -n "${FW_HOOK_TEMPFILE:-}" ]; then
+    trap 'rm -f "$FW_HOOK_TEMPFILE"' EXIT
+fi
+
+INSTALL_DIR="/kloudust/system/libvirt-hooks"
+INSTALL_FILE="$INSTALL_DIR/qemu"
+STATE_DIR="/kloudust/system/firewall-state"
+
+echoerr() { echo "$@" 1>&2; }
+
+function deleteChainsByComment() {
+    local COMMENT="$1"
+    # Remove any existing chains for this VM/ruleset before rebuilding them.
+    # This keeps the reapply path idempotent if the hook runs more than once.
+    while read -r FAMILY TABLE CHAIN; do
+        if [ -z "$FAMILY" ] || [ -z "$TABLE" ] || [ -z "$CHAIN" ]; then continue; fi
+        nft delete chain "$FAMILY" "$TABLE" "$CHAIN" 2>/dev/null || true
+    done < <(nft -j list ruleset | jq -r --arg comment "$COMMENT" '
+      .nftables[] | select(.chain) | .chain |
+      select(.comment == $comment) |
+      "\(.family) \(.table) \(.name)"
+    ')
+}
+
+function reapplyFirewallState() {
+    local HOOK_VM_NAME="$1"
+    local STATE_FILE="$2"
+    local DOMAIN_XML="$3"
+    if [ ! -f "$STATE_FILE" ]; then return 0; fi
+
+    # Rebuild one VM/VNet firewall from the saved state file and the live XML.
+    # shellcheck disable=SC1090
+    . "$STATE_FILE" || { echoerr "Unable to read firewall state file $STATE_FILE"; return 0; }
+    if [ -z "$FW_VM_NAME" ] || [ -z "$FW_VNET_ID" ] || [ -z "$FW_RULESET_NAME" ] || [ -z "$FW_RULES_JSON_B64" ]; then
+        echoerr "Incomplete firewall state in $STATE_FILE, skipping."
+        return 0
+    fi
+    if [ "$FW_VM_NAME" != "$HOOK_VM_NAME" ]; then return 0; fi
+
+    local RULES_JSON BR_NAME MAC_ADDRESS HOST_MAC VNET_IFACE EGRESS_CHAIN INGRESS_CHAIN COMMENT
+    RULES_JSON="$(printf '%s' "$FW_RULES_JSON_B64" | base64 -d 2>/dev/null)"
+    if [ -z "$RULES_JSON" ]; then
+        echoerr "Unable to decode firewall rules for $FW_VM_NAME from $STATE_FILE, skipping."
+        return 0
+    fi
+
+    BR_NAME="kd${FW_VNET_ID}_br"
+    # Use the domain XML libvirt passed on stdin so reapply stays in-hook.
+    MAC_ADDRESS=""
+    if [ -n "$DOMAIN_XML" ]; then
+        MAC_ADDRESS="$(printf '%s' "$DOMAIN_XML" | xmllint --xpath \
+            "string(//interface[@type='bridge'][source/@bridge='$BR_NAME']/mac/@address)" - 2>/dev/null)"
+    fi
+    if [ -z "$MAC_ADDRESS" ]; then
+        echoerr "Could not locate MAC for $FW_VM_NAME on bridge $BR_NAME from domain XML, skipping firewall reapply."
+        return 0
+    fi
+
+    HOST_MAC="$(echo "$MAC_ADDRESS" | sed 's/^../fe/')"
+    VNET_IFACE=""
+    for _ in 1 2 3 4 5; do
+        VNET_IFACE="$(ip -br link | awk -v mac="$HOST_MAC" 'tolower($3) == tolower(mac) {print $1; exit}')"
+        [ -n "$VNET_IFACE" ] && break
+        sleep 1
+    done
+    if [ -z "$VNET_IFACE" ]; then
+        echoerr "Could not find host vnet interface for firewall reapply of $FW_VM_NAME on VNet $FW_VNET_ID"
+        return 0
+    fi
+
+    EGRESS_CHAIN="kd_$(echo "${FW_RULESET_NAME}_${FW_VM_NAME}_${FW_VNET_ID}_e" | md5sum | cut -c1-24)_e"
+    INGRESS_CHAIN="kd_$(echo "${FW_RULESET_NAME}_${FW_VM_NAME}_${FW_VNET_ID}_i" | md5sum | cut -c1-24)_i"
+    COMMENT="$FW_RULESET_NAME-$FW_VM_NAME-$FW_VNET_ID"
+    nft add table netdev kdhostfirewall_netdev 2>/dev/null || true
+    deleteChainsByComment "$COMMENT"
+
+    if ! nft add chain netdev kdhostfirewall_netdev "$EGRESS_CHAIN" \
+        { type filter hook egress device \"$VNET_IFACE\" priority 0\; policy accept\; comment \"$COMMENT\"\; }; then
+        echoerr "Could not recreate egress firewall chain for $FW_VM_NAME on $VNET_IFACE"
+        return 0
+    fi
+
+    if ! nft add chain netdev kdhostfirewall_netdev "$INGRESS_CHAIN" \
+        { type filter hook ingress device \"$VNET_IFACE\" priority 0\; policy accept\; comment \"$COMMENT\"\; }; then
+        echoerr "Could not recreate ingress firewall chain for $FW_VM_NAME on $VNET_IFACE"
+        return 0
+    fi
+
+    if ! nft add rule netdev kdhostfirewall_netdev "$EGRESS_CHAIN" ether type arp accept comment "$COMMENT"; then return 0; fi
+    if ! nft add rule netdev kdhostfirewall_netdev "$INGRESS_CHAIN" ether type arp accept comment "$COMMENT"; then return 0; fi
+
+    while read -r RULE; do
+        DIRECTION="$(echo "$RULE" | jq -r '.direction')"
+        ALLOW="$(echo "$RULE" | jq -r '.allow')"
+        PROTOCOL="$(echo "$RULE" | jq -r '.protocol')"
+        PORT="$(echo "$RULE" | jq -r '.port')"
+        IP="$(echo "$RULE" | jq -r '.ip')"
+
+        ACTION="drop"
+        if [ "$ALLOW" = "true" ]; then ACTION="accept"; fi
+
+        PORT_MATCH=""
+        if { [ "$PROTOCOL" = "tcp" ] || [ "$PROTOCOL" = "udp" ]; } && [ -n "$PORT" ] && [ "$PORT" != "*" ] && [ "$PORT" != "null" ]; then
+            PORT_MATCH="$PROTOCOL dport $PORT"
+        elif { [ "$PROTOCOL" = "tcp" ] || [ "$PROTOCOL" = "udp" ]; } && [ "$PORT" = "*" ]; then
+            PORT_MATCH="meta l4proto $PROTOCOL"  
+        fi
+
+        IP_MATCH=""
+        if [ "$DIRECTION" = "in" ]; then
+            CHAIN="$EGRESS_CHAIN"
+            if [ "$IP" != "*" ] && [ "$IP" != "null" ]; then IP_MATCH="ip saddr $IP"; fi
+        else
+            CHAIN="$INGRESS_CHAIN"
+            if [ "$IP" != "*" ] && [ "$IP" != "null" ]; then IP_MATCH="ip daddr $IP"; fi
+        fi
+
+        if ! nft add rule netdev kdhostfirewall_netdev "$CHAIN" \
+                $IP_MATCH $PORT_MATCH counter $ACTION comment "$COMMENT"; then
+            echoerr "Could not recreate firewall rule for $FW_VM_NAME from $STATE_FILE"
+            return 0
+        fi
+    done < <(echo "$RULES_JSON" | jq -c '.[]')
+
+    if ! nft list ruleset > /etc/nftables.conf; then
+        echoerr "Could not persist reapplied firewall rules for $FW_VM_NAME"
+        return 0
+    fi
+    systemctl enable nftables >/dev/null 2>&1 || true
+
+    echo "Netdev egress+ingress firewall rules reapplied for $FW_VM_NAME, ruleset $FW_RULESET_NAME and Vnet $FW_VNET_ID"
+}
+
+# The SSH fallback transport used by host init does not preserve argv, so the
+# installer arrives with no shell arguments. Treat that as install mode too.
+if [ "${1:-}" = "install" ] || [ $# -eq 0 ]; then
+    # Host bootstrap installs the hook once and publishes it at libvirt's
+    # expected hook path.
+    if ! sudo mkdir -p "$INSTALL_DIR"; then exit 1; fi
+    if ! sudo mkdir -p "$STATE_DIR"; then exit 1; fi
+    if ! sudo mkdir -p /etc/libvirt/hooks; then exit 1; fi
+    if ! sudo cp "$0" "$INSTALL_FILE"; then exit 1; fi
+    if ! sudo chmod 755 "$INSTALL_FILE"; then exit 1; fi
+    if ! sudo ln -sfn "$INSTALL_FILE" /etc/libvirt/hooks/qemu; then exit 1; fi
+    echo "Libvirt qemu firewall hook installed."
+    exit 0
+fi
+
+HOOK_VM_NAME="$1"
+HOOK_OPERATION="$2"
+HOOK_SUBOPERATION="$3"
+
+if [ -z "$HOOK_VM_NAME" ] || [ -z "$HOOK_OPERATION" ] || [ -z "$HOOK_SUBOPERATION" ]; then
+    exit 0
+fi
+
+DOMAIN_XML=""
+if [ ! -t 0 ]; then
+    DOMAIN_XML="$(cat)"
+fi
+
+# Only VM start and libvirt reconnect events should trigger firewall restore.
+case "$HOOK_OPERATION/$HOOK_SUBOPERATION" in
+    started/begin|reconnect/begin) ;;
+    *) exit 0 ;;
+esac
+
+if [ -d "$STATE_DIR" ]; then
+    # Replay only the saved firewall state for this host's VMs.
+    shopt -s nullglob
+    for STATE_FILE in "$STATE_DIR"/*.state; do
+        reapplyFirewallState "$HOOK_VM_NAME" "$STATE_FILE" "$DOMAIN_XML"
+    done
+    shopt -u nullglob
+fi
+
+exit 0

--- a/backend/apps/kloudust/lib/cmd/scripts/removeFirewallRuleset.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/removeFirewallRuleset.sh
@@ -12,6 +12,7 @@
 VNET_ID="{1}"
 VM_NAME="{2}"
 RULESET_NAME="{3}"
+STATE_DIR="/kloudust/system/firewall-state"
 
 echoerr() { echo "$@" 1>&2; }
 
@@ -25,7 +26,10 @@ if [ -z "$VNET_ID" ] || [ -z "$VM_NAME" ] || [ -z "$RULESET_NAME" ]; then
     exitFailed
 fi
 
-# Delete the chains, as the firewall table is shared
+STATE_ID=$(printf '%s' "${VM_NAME}|${VNET_ID}|${RULESET_NAME}" | md5sum | cut -d" " -f1)
+STATE_FILE="$STATE_DIR/${STATE_ID}.state"
+
+# Delete the chains, as the netdev table is shared
 while read -r family table chain; do
     if ! sudo nft delete chain "$family" "$table" "$chain"; then exitFailed; fi
 done < <(sudo nft -j list ruleset | jq -r --arg comment "$RULESET_NAME-$VM_NAME-$VNET_ID" '
@@ -38,6 +42,9 @@ done < <(sudo nft -j list ruleset | jq -r --arg comment "$RULESET_NAME-$VM_NAME-
 # Persist
 if ! sudo nft list ruleset | sudo tee /etc/nftables.conf > /dev/null; then exitFailed; fi 
 if ! sudo systemctl enable nftables; then exitFailed; fi
+if ! sudo rm -f "$STATE_FILE"; then
+    echoerr "Warning: Could not remove firewall reapply state $STATE_FILE"
+fi
 
-echo "Bridge forward firewall rules removed for $VM_NAME, ruleset $RULESET_NAME and Vnet $VNET_ID"
+echo "Netdev egress+ingress firewall rules removed for $VM_NAME, ruleset $RULESET_NAME and Vnet $VNET_ID"
 exit 0


### PR DESCRIPTION
### Automatic Firewall Restoration via Libvirt Hook

This PR changes 5 files because the fix covers the full firewall lifecycle: install the libvirt hook at host setup, save the VM firewall state when rules are applied, clean it up when rules are removed, and reapply it automatically when the VM starts again.

**Setup**

* `addHost.js` installs the hook during host initialization by running `firewallHook.sh install`.
* The hook is installed at `/kloudust/system/libvirt-hooks/qemu` and linked to `/etc/libvirt/hooks/qemu`.
* An AppArmor rule is also added to allow `libvirtd` to execute the hook.

**How it works**

* `applyFirewallRuleset.sh` applies nftables rules and saves the firewall state under `/kloudust/system/firewall-state/`.
* When a VM starts or reconnects, the libvirt hook reads the saved state and re-applies the firewall rules automatically.
* `removeFirewallRuleset.sh` removes both the firewall rules and the saved state file.

