### PR TITLE
Fix firewall hook and refresh VM metadata on NIC changes

### DIFF
--- a/backend/apps/kloudust/lib/cmd/applyFirewallRuleset.js
+++ b/backend/apps/kloudust/lib/cmd/applyFirewallRuleset.js
@@ -58,7 +58,7 @@ module.exports.exec = async function(params) {
         other: [
             vm_host.hostaddress, vm_host.rootid, vm_host.rootpw, vm_host.hostkey, vm_host.port, 
             `${KLOUD_CONSTANTS.LIBDIR}/cmd/scripts/applyFirewallRuleset.sh`, 
-            rules_json, vnet.vnetnum, vm.name, ruleset.name
+            rules_json, vnet.vnetnum, vm.name, ruleset.name, vnet.name
         ] 
     };
     

--- a/backend/apps/kloudust/lib/cmd/removeFirewallRuleset.js
+++ b/backend/apps/kloudust/lib/cmd/removeFirewallRuleset.js
@@ -52,7 +52,7 @@ module.exports.exec = async function(params) {
         other: [
             host.hostaddress, host.rootid, host.rootpw, host.hostkey, host.port, 
             `${KLOUD_CONSTANTS.LIBDIR}/cmd/scripts/removeFirewallRuleset.sh`,
-            vnet.vnetnum, vm.name, ruleset.name
+            vnet.vnetnum, vm.name, ruleset.name, vnet.name
         ] 
     };
     

--- a/backend/apps/kloudust/lib/cmd/scripts/addHost.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/addHost.sh
@@ -214,12 +214,13 @@ if ! sudo chmod +x /etc/libvirt/hooks/qemu; then exitFailed; fi
 # Create firewall hook script for VMs
 sudo tee "/kloudust/system/vmhooks/010-start-vmfirewall" > /dev/null <<EOF
 #!/bin/bash
-if [ -n "\$1" ] && [ "\$1" != "started" ]; then exit 0; fi  # we only run on VM starts
+if [ -n "\$1" ] && ([ "\$2" != "started" ] || [ "\$3" != "begin" ]); then exit 0; fi
 VM_NAME="\$1"
-if [ -n "\$VM_NAME" ] && [ -f "/kloudust/system/firewall/fw_\${VM_NAME}.sh" ]; then
-    /bin/bash /kloudust/system/firewall/fw_\${VM_NAME}.sh
-    echo "\$(date '+%Y-%m-%d %H:%M:%S') Firewall re-applied for \${VM_NAME}." >> /kloudust/temp/kdlog
-fi
+for FW_SCRIPT in /kloudust/system/firewall/fw_\${VM_NAME}_*.sh; do
+    [ -f "\$FW_SCRIPT" ] || continue
+    /bin/bash "\$FW_SCRIPT"
+    echo "\$(date '+%Y-%m-%d %H:%M:%S') Firewall re-applied for \${VM_NAME} from \${FW_SCRIPT}." >> /kloudust/temp/kdlog
+done
 EOF
 if [ $? -ne 0 ]; then exitFailed; fi
 if ! sudo chmod +x /kloudust/system/vmhooks/010-start-vmfirewall; then exitFailed; fi  

--- a/backend/apps/kloudust/lib/cmd/scripts/applyFirewallRuleset.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/applyFirewallRuleset.sh
@@ -8,6 +8,7 @@
 #  2 - VNet ID for getting mac address of vm interface and for unique comment to grep handles later
 #  3 - VM Name for unique comment to grep handles later
 #  4 - Ruleset name for unique comment to grep handles later
+#  5 - VNet name for unique persisted firewall replay filename
 #
 # (C) 2026 Tekmonks. All rights reserved.
 #########################################################################################################
@@ -16,6 +17,7 @@ RULES_JSON="{1}"
 VNET_ID="{2}"
 VM_NAME="{3}"
 RULESET_NAME="{4}"
+VNET_NAME="{5}"
 BR_NAME="kd${VNET_ID}_br"
 
 echoerr() { echo "$@" 1>&2; }
@@ -25,8 +27,8 @@ function exitFailed() {
     exit 1
 }
 
-# Get VM's MAC address from virsh
-MAC_ADDRESS=`virsh dumpxml $VM_NAME | xmllint --xpath "string(//interface[@type='bridge'][source/@bridge='$BR_NAME']/mac/@address)" -`
+# Get VM's MAC address 
+MAC_ADDRESS=`xmllint --xpath "string(//interface[@type='bridge'][source/@bridge='$BR_NAME']/mac/@address)" /kloudust/metadata/${VM_NAME}.xml`
 if [ -z "$MAC_ADDRESS" ]; then
     echoerr "Could not locate MAC for the VM $VM_NAME attached to VNet $VNET_ID or already detached, skipping."
     exitFailed
@@ -128,9 +130,9 @@ if [ "$RULES_FAILED" = "1" ]; then
 fi
 
 # Persist only if not already running from the firewall directory
-if [ "$0" != "/kloudust/system/firewall/fw_$VM_NAME.sh" ]; then
-    if ! cp "$0" /kloudust/system/firewall/fw_$VM_NAME.sh; then exitFailed; fi
-    if ! sudo chmod 755 /kloudust/system/firewall/fw_$VM_NAME.sh; then exitFailed; fi
+if [ "$0" != "/kloudust/system/firewall/fw_${VM_NAME}_${VNET_NAME}.sh" ]; then
+    if ! cp "$0" "/kloudust/system/firewall/fw_${VM_NAME}_${VNET_NAME}.sh"; then exitFailed; fi
+    if ! sudo chmod 755 "/kloudust/system/firewall/fw_${VM_NAME}_${VNET_NAME}.sh"; then exitFailed; fi
 fi
 
 echo "Firewall rules applied for $VM_NAME, ruleset $RULESET_NAME and Vnet $VNET_ID"

--- a/backend/apps/kloudust/lib/cmd/scripts/attachVMToVxLANBridge.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/attachVMToVxLANBridge.sh
@@ -30,4 +30,5 @@ if [ -n "$MAC" ]; then
 fi
 
 if ! virsh attach-interface --domain $VM_NAME --type bridge --source "$BR_NAME" --target "$NANO_ID" --model virtio --config --live; then exitFailed; fi
+if ! virsh dumpxml "$VM_NAME" > "/kloudust/metadata/${VM_NAME}.xml"; then exitFailed; fi
 echo Done.

--- a/backend/apps/kloudust/lib/cmd/scripts/detachVMFromVxLANBridge.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/detachVMFromVxLANBridge.sh
@@ -31,5 +31,6 @@ fi
 
 if [ -n "$VM_NAME" ]; then                                                       
     if ! virsh detach-interface --domain $VM_NAME --type bridge --mac $MAC --config --live; then exitFailed; fi
+    if ! virsh dumpxml "$VM_NAME" > "/kloudust/metadata/${VM_NAME}.xml"; then exitFailed; fi
 fi
 echo Done.

--- a/backend/apps/kloudust/lib/cmd/scripts/removeFirewallRuleset.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/removeFirewallRuleset.sh
@@ -12,6 +12,7 @@
 VNET_ID="{1}"
 VM_NAME="{2}"
 RULESET_NAME="{3}"
+VNET_NAME="{4}"
 
 echoerr() { echo "$@" 1>&2; }
 
@@ -34,6 +35,10 @@ done < <(sudo nft -j list ruleset | jq -r --arg comment "$RULESET_NAME-$VM_NAME-
   "\(.family) \(.table) \(.name)"
 ')
 
+# Remove only the persisted replay script for this specific VM/VNet/ruleset.
+if [ -f "/kloudust/system/firewall/fw_${VM_NAME}_${VNET_NAME}.sh" ]; then
+    if ! rm -f "/kloudust/system/firewall/fw_${VM_NAME}_${VNET_NAME}.sh"; then exitFailed; fi
+fi
 
 # Persist
 if ! sudo nft list ruleset | sudo tee /etc/nftables.conf > /dev/null; then exitFailed; fi 


### PR DESCRIPTION
This PR contains two commits that fix two different problems, but both are related to each other.

### Fixed two issues

- This fixes the VM firewall hook so the correct firewall rules get reapplied when the VM starts.

- It also updates the saved VM metadata whenever a network card is attached or detached, so the XML stays in sync with the VM’s actual network setup and we don’t end up using stale NIC details.


Together, these changes ensure firewall rules are regenerated from up-to-date network configuration and remain consistent across VM lifecycle events.
