### PR TITLE
[Feature] Routers

### DIFF
--- a/backend/apps/kloudust/db/kd_dbschema.jsonx
+++ b/backend/apps/kloudust/db/kd_dbschema.jsonx
@@ -80,5 +80,10 @@
         projectid varchar not null, \
         timestamp integer default (cast(strftime('%s','now') || substr(strftime('%f','now'),4) as integer)))",
 
+    // routers table
+    "CREATE TABLE routers(id varchar not null primary key, name varchar not null, name_raw varchar not null, \
+        description varchar, hostname varchar not null, org varchar not null, projectid varchar not null, \
+        timestamp integer default (cast(strftime('%s','now') || substr(strftime('%f','now'),4) as integer)))",
+
     "COMMIT TRANSACTION"
 ]

--- a/backend/apps/kloudust/lib/cmd/createRouter.js
+++ b/backend/apps/kloudust/lib/cmd/createRouter.js
@@ -8,6 +8,7 @@
  */
 
 const roleman = require(`${KLOUD_CONSTANTS.LIBDIR}/roleenforcer.js`);
+const crypto = require('crypto');
 const CMD_CONSTANTS = require(`${KLOUD_CONSTANTS.LIBDIR}/cmd/cmdconstants.js`);
 const dbAbstractor = require(`${KLOUD_CONSTANTS.LIBDIR}/dbAbstractor.js`);
 const vnetModule = require(`${KLOUD_CONSTANTS.LIBDIR}/vnet.js`);
@@ -35,7 +36,7 @@ module.exports.exec = async function(params) {
     const vnet_promises = vnets.map(async vnet => {
         const vnet_details = await dbAbstractor.getVnet(vnetModule.resolveVnetName(vnet.vnet));
         if (!vnet_details) return false;
-        return { ...vnet_details, gateway_address: vnet.ip }
+        return { ...vnet_details, gateway_address: vnet.ip, vnet_name_hash: crypto.createHash('sha256').update(vnet_details.name,'utf8').digest('hex').slice(0,12) };
     });
 
     const vnet_infos = await Promise.all(vnet_promises);
@@ -70,7 +71,7 @@ module.exports.exec = async function(params) {
         console: params.consoleHandlers,
         other: [hostInfo.hostaddress, hostInfo.rootid, hostInfo.rootpw, hostInfo.hostkey, hostInfo.port,
             `${KLOUD_CONSTANTS.LIBDIR}/cmd/scripts/createRouter.sh`, router_name, 
-            JSON.stringify(JSON.stringify(vnet_infos.map(vnet_info => ({vnet: vnet_info.name, gateway_address: vnet_info.gateway_address, vnetnum: vnet_info.vnetnum}))))
+            JSON.stringify(JSON.stringify(vnet_infos.map(vnet_info => ({vnet: vnet_info.name, gateway_address: vnet_info.gateway_address, vnetnum: vnet_info.vnetnum, vnet_name_hash: vnet_info.vnet_name_hash}))))
         ]
     }
 

--- a/backend/apps/kloudust/lib/cmd/createRouter.js
+++ b/backend/apps/kloudust/lib/cmd/createRouter.js
@@ -1,0 +1,102 @@
+/** 
+ * createRouter.js - Creates a router between multiple VNets.
+ * 
+ * Params - 0 - Router Name, 1 - Router Description, 2 - Array of Vnets to connect and their gateway addresses
+ * 
+ * (C) 2026 TekMonks. All rights reserved.
+ * License: See enclosed LICENSE file.
+ */
+
+const roleman = require(`${KLOUD_CONSTANTS.LIBDIR}/roleenforcer.js`);
+const CMD_CONSTANTS = require(`${KLOUD_CONSTANTS.LIBDIR}/cmd/cmdconstants.js`);
+const dbAbstractor = require(`${KLOUD_CONSTANTS.LIBDIR}/dbAbstractor.js`);
+const vnetModule = require(`${KLOUD_CONSTANTS.LIBDIR}/vnet.js`);
+const {xforge} = require(`${KLOUD_CONSTANTS.THIRD_PARTY_DIR}/xforge/xforge`);
+const deleteRouter = require(`${KLOUD_CONSTANTS.LIBDIR}/cmd/deleteRouter.js`);
+
+/**
+ * Creates a router between multiple VNets
+ * @param {array} params The incoming params, see above for param documentation.
+ */
+
+module.exports.exec = async function(params) {
+    if (!roleman.checkAccess(roleman.ACTIONS.edit_project_resource)) {params.consoleHandlers.LOGUNAUTH(); return CMD_CONSTANTS.FALSE_RESULT();}
+    const [router_name_raw, router_description, router_vnets] = [...params];
+    const router_name = exports.resolveRouterName(router_name_raw);
+    const vnets = JSON.parse(router_vnets);
+
+    const routerExists = await dbAbstractor.getRouter(router_name);
+
+    if(routerExists) {
+        params.consoleHandlers.LOGERROR(`A router with the name ${router_name} already exists. Aborting.`);
+        return CMD_CONSTANTS.FALSE_RESULT(`Failed to create router. A router with the name ${router_name} already exists.`);
+    }
+
+    const vnet_promises = vnets.map(async vnet => {
+        const vnet_details = await dbAbstractor.getVnet(vnetModule.resolveVnetName(vnet.vnet));
+        if (!vnet_details) return false;
+        return { ...vnet_details, gateway_address: vnet.ip }
+    });
+
+    const vnet_infos = await Promise.all(vnet_promises);
+
+    if(vnet_infos.some(vnet_info => !vnet_info)) {
+        params.consoleHandlers.LOGERROR(`One or more VNets do not exist. Aborting router creation.`);
+        return CMD_CONSTANTS.FALSE_RESULT(`Failed to create router. One or more VNets do not exist.`);
+    }
+
+    const host = await dbAbstractor.getHostWithVnets(vnet_infos.map(_=>_.id));
+
+    if(!host) {
+        params.consoleHandlers.LOGERROR(`Cannot create router in an empty vnet.`);
+        return CMD_CONSTANTS.FALSE_RESULT(`Cannot create router in an empty vnet.`);
+    }
+    
+    const hostInfo = await dbAbstractor.getHostEntry(host.hostname);
+    
+    if(host.matched_vnet_count != vnet_infos.length) {
+        const missing_vnets = vnet_infos.filter(vnet_info => !host.matched_vnets.split(",").includes(vnet_info.id))
+        const vnetExpansionPromises= missing_vnets.map(missing_vnet => vnetModule.expandVnetToHost(missing_vnet.name, host.hostname, params.consoleHandlers, false));
+        const missingVNetExpansionResults = await Promise.all(vnetExpansionPromises);
+        if(missingVNetExpansionResults.some(result => !result)) {
+            params.consoleHandlers.LOGERROR(`Vnet expansion to router host ${host.hostname} failed. Aborting router creation.`);
+            return CMD_CONSTANTS.FALSE_RESULT(`Failed to create router. Vnet expansion to router host ${host.hostname} failed.`);
+        }
+    }
+
+    const xforgeArgs = {
+        colors: KLOUD_CONSTANTS.COLORED_OUT, 
+        file: `${KLOUD_CONSTANTS.THIRD_PARTY_DIR}/xforge/samples/remoteCmd.xf.js`,
+        console: params.consoleHandlers,
+        other: [hostInfo.hostaddress, hostInfo.rootid, hostInfo.rootpw, hostInfo.hostkey, hostInfo.port,
+            `${KLOUD_CONSTANTS.LIBDIR}/cmd/scripts/createRouter.sh`, router_name, 
+            JSON.stringify(JSON.stringify(vnet_infos.map(vnet_info => ({vnet: vnet_info.name, gateway_address: vnet_info.gateway_address, vnetnum: vnet_info.vnetnum}))))
+        ]
+    }
+
+    const results = await xforge(xforgeArgs);
+
+    if(results.result){
+        const routerAddResult = await dbAbstractor.addOrUpdateRouterToDB(router_name,router_name_raw,router_description,host.hostname);
+        if(routerAddResult){
+            const vnetRouterAddResults = await Promise.all(vnet_infos.map(vnet_info => dbAbstractor.addRouterVnetIP(router_name, vnet_info.name, vnet_info.gateway_address))); //add all router-vnet-ip relations in db
+            if(vnetRouterAddResults.every(result => result)) {
+                params.consoleHandlers.LOGINFO(`Router ${router_name} created successfully.`);
+                return CMD_CONSTANTS.TRUE_RESULT("Router created successfully");
+            }else{
+                const deleteRouterParams = [router_name_raw]; deleteRouterParams.consoleHandlers = params.consoleHandlers;
+                const deleteRouterResult = await deleteRouter.exec(deleteRouterParams);
+                if(!deleteRouterResult.result) params.consoleHandlers.LOGERROR(`Router cleanup failed. Manual cleanup might be required for router ${router_name} on host ${host.hostname}`);
+            }
+        }else{
+            const deleteResults = await deleteRouter.deleteRouterFromHost(router_name, hostInfo, params.consoleHandlers); //cleanup router from host if db addition failed
+            if(!deleteResults.result) params.consoleHandlers.LOGERROR(`Router cleanup failed. Manual cleanup might be required for router ${router_name} on host ${host.hostname}`);
+        }
+    }
+
+    params.consoleHandlers.LOGERROR(`Failed to create router. ${router_name} output ${results}`);
+    return CMD_CONSTANTS.FALSE_RESULT(`Failed to create router.`);
+}
+
+
+exports.resolveRouterName = (router_name_raw, project) => router_name_raw?`${router_name_raw}_${KLOUD_CONSTANTS.env.org()}_${project||KLOUD_CONSTANTS.env.prj()}`.toLowerCase().replace(/\s/g,"_"):null;

--- a/backend/apps/kloudust/lib/cmd/deleteRouter.js
+++ b/backend/apps/kloudust/lib/cmd/deleteRouter.js
@@ -1,0 +1,53 @@
+/** 
+ * deleteRouter.js - Deletes the given Router.
+  It will also delete the Vnet relationships in the DB for this Router.
+ * 
+ * Params - 0 - Router Name
+ * 
+ * (C) 2026 TekMonks. All rights reserved.
+ * License: See enclosed LICENSE file.
+ */
+
+const roleman = require(`${KLOUD_CONSTANTS.LIBDIR}/roleenforcer.js`);
+const dbAbstractor = require(`${KLOUD_CONSTANTS.LIBDIR}/dbAbstractor.js`);
+const {xforge} = require(`${KLOUD_CONSTANTS.THIRD_PARTY_DIR}/xforge/xforge`);
+const createRouter = require(`${KLOUD_CONSTANTS.LIBDIR}/cmd/createRouter.js`);
+
+/**
+ * Deletes the given Router
+ * @param {array} params The incoming params, see above for param documentation.
+ */
+module.exports.exec = async function(params) {
+    if (!roleman.checkAccess(roleman.ACTIONS.edit_project_resource)) {params.consoleHandlers.LOGUNAUTH(); return CMD_CONSTANTS.FALSE_RESULT();}
+    const router_name_raw = params[0], router_name = createRouter.resolveRouterName(router_name_raw);
+
+    const router = await dbAbstractor.getRouter(router_name);
+    if (!router) {params.consoleHandlers.LOGERROR("Bad Router name or Router not found"); return CMD_CONSTANTS.FALSE_RESULT();}
+    
+    const hostInfo = await dbAbstractor.getHostEntry(router.hostname); 
+    if (!hostInfo) {params.consoleHandlers.LOGERROR("Bad hostname for the router or host not found"); return CMD_CONSTANTS.FALSE_RESULT();}
+
+    const results = await exports.deleteRouterFromHost(router_name, hostInfo, params.consoleHandlers);
+     if (results.result) {
+        if (!await dbAbstractor.removeAllRouterVnetIPRelationships(router.name))
+            params.consoleHandlers.LOGERROR("DB failed to delete all Router-Vnets-IP for Router "+router_name);
+        if (await dbAbstractor.deleteRouter(router_name)) return results;
+        else {params.consoleHandlers.LOGERROR("DB failed"); return {...results, result: false};}
+    } else return results;
+    
+}
+
+exports.deleteRouterFromHost = async function(router_name, hostInfo, console) {
+    const xforgeArgs = {
+        colors: KLOUD_CONSTANTS.COLORED_OUT, 
+        file: `${KLOUD_CONSTANTS.THIRD_PARTY_DIR}/xforge/samples/remoteCmd.xf.js`,
+        console,
+        other: [
+            hostInfo.hostaddress, hostInfo.rootid, hostInfo.rootpw, hostInfo.hostkey, hostInfo.port,
+            `${KLOUD_CONSTANTS.LIBDIR}/cmd/scripts/deleteRouter.sh`, router_name
+        ]
+    }
+
+    const results = await xforge(xforgeArgs);
+    return results;
+}

--- a/backend/apps/kloudust/lib/cmd/scripts/createRouter.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/createRouter.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Params
+# {1} The router name
+# {2} The JSON string containing the VNet and gateway IP information. It should be an array of objects with the following structure: [{"vnet": "vnet_name", "gateway_ip": "gateway_ip", vnetnum: 1}, ...]
+
+ROUTER_NAME="{1}"
+VNET_GATEWAYS={2}
+
+function exitFailed() {
+    echo "Failed"
+    exit 1
+}
+
+echo "Configuring router namespace: ${ROUTER_NAME}"
+
+if ! ip netns list | awk '{print $1}' | grep -Fxq "${ROUTER_NAME}"; then
+    if ! ip netns add "${ROUTER_NAME}"; then exitFailed; fi
+fi
+
+if ! ip netns exec "${ROUTER_NAME}" ip link set lo up; then exitFailed; fi
+
+if ! ip netns exec "${ROUTER_NAME}" sysctl -q -w net.ipv4.ip_forward=1 >/dev/null; then exitFailed; fi
+
+while read -r entry; do
+
+    VNET_NAME=$(jq -r '.vnet' <<< "${entry}")
+    GATEWAY_IP=$(jq -r '.gateway_address' <<< "${entry}")
+    VNET_NUM=$(jq -r '.vnetnum' <<< "${entry}")
+
+    if [[ -z "${VNET_NAME}" || "${VNET_NAME}" == "null" ]]; then
+        echo "Invalid vnet field"
+        exitFailed
+    fi
+
+    if [[ -z "${GATEWAY_IP}" || "${GATEWAY_IP}" == "null" ]]; then
+        echo "Invalid gateway_ip field"
+        exitFailed
+    fi
+
+    if [[ -z "${VNET_NUM}" || "${VNET_NUM}" == "null" ]]; then
+        echo "Invalid vnetnum field"
+        exitFailed
+    fi
+
+    BRIDGE_NAME="kd${VNET_NUM}_br"
+
+    VNET_NAME_HASH=$(echo -n "$VNET_NAME" | sha256sum | cut -c1-12)
+    VETH_BR="${VNET_NAME_HASH}_br"
+    VETH_NS="${VNET_NAME_HASH}_ns"
+
+    echo "Configuring ${VNET_NAME}"
+    echo "  Bridge: ${BRIDGE_NAME}"
+    echo "  Gateway: ${GATEWAY_IP}"
+
+    if ! ip link show "${BRIDGE_NAME}" >/dev/null 2>&1; then
+        echo "Bridge does not exist: ${BRIDGE_NAME}"
+        exitFailed
+    fi
+
+    if ! ip link del "${VETH_BR}" >/dev/null 2>&1; then exitFailed; fi
+
+    if ! ip netns exec "${ROUTER_NAME}" ip link del "${VETH_NS}" >/dev/null 2>&1; then exitFailed; fi
+
+    if ! ip link add "${VETH_BR}" type veth peer name "${VETH_NS}"; then exitFailed; fi
+
+    if ! ip link set "${VETH_NS}" netns "${ROUTER_NAME}"; then exitFailed; fi
+
+    if ! ip link set "${VETH_BR}" master "${BRIDGE_NAME}"; then exitFailed; fi
+
+    if ! ip link set "${VETH_BR}" up; then exitFailed; fi
+
+    if ! ip netns exec "${ROUTER_NAME}" ip addr replace "${GATEWAY_IP}/24" dev "${VETH_NS}"; then exitFailed; fi
+
+    if ! ip netns exec "${ROUTER_NAME}" ip link set "${VETH_NS}" up; then exitFailed; fi
+
+done < <(jq -c '.[]' <<< "${VNET_GATEWAYS}")
+
+echo "Router '${ROUTER_NAME}' configured successfully"

--- a/backend/apps/kloudust/lib/cmd/scripts/createRouter.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/createRouter.sh
@@ -7,6 +7,9 @@
 ROUTER_NAME="{1}"
 VNET_GATEWAYS={2}
 
+SCRIPT_PATH=$(readlink -f "$0")
+ROUTER_BOOT_SCRIPT="/kloudust/system/hostinit/30router_${ROUTER_NAME}.sh"
+
 function exitFailed() {
     echo "Failed"
     exit 1
@@ -75,5 +78,10 @@ while read -r entry; do
     if ! ip netns exec "${ROUTER_NAME}" ip link set "${VETH_NS}" up; then exitFailed; fi
 
 done < <(jq -c '.[]' <<< "${VNET_GATEWAYS}")
+
+if [ "$0" != "$ROUTER_BOOT_SCRIPT" ]; then
+    cp $SCRIPT_PATH $ROUTER_BOOT_SCRIPT                                   
+    chmod +x $ROUTER_BOOT_SCRIPT
+fi;
 
 echo "Router '${ROUTER_NAME}' configured successfully"

--- a/backend/apps/kloudust/lib/cmd/scripts/createRouter.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/createRouter.sh
@@ -30,6 +30,7 @@ while read -r entry; do
     VNET_NAME=$(jq -r '.vnet' <<< "${entry}")
     GATEWAY_IP=$(jq -r '.gateway_address' <<< "${entry}")
     VNET_NUM=$(jq -r '.vnetnum' <<< "${entry}")
+    VNET_NAME_HASH=$(jq -r '.vnet_name_hash' <<< "${entry}")
 
     if [[ -z "${VNET_NAME}" || "${VNET_NAME}" == "null" ]]; then
         echo "Invalid vnet field"
@@ -47,8 +48,6 @@ while read -r entry; do
     fi
 
     BRIDGE_NAME="kd${VNET_NUM}_br"
-
-    VNET_NAME_HASH=$(echo -n "$VNET_NAME" | sha256sum | cut -c1-12)
     VETH_BR="${VNET_NAME_HASH}_br"
     VETH_NS="${VNET_NAME_HASH}_ns"
 
@@ -61,9 +60,9 @@ while read -r entry; do
         exitFailed
     fi
 
-    if ! ip link del "${VETH_BR}" >/dev/null 2>&1; then exitFailed; fi
-
-    if ! ip netns exec "${ROUTER_NAME}" ip link del "${VETH_NS}" >/dev/null 2>&1; then exitFailed; fi
+    if ip link show "${VETH_BR}" >/dev/null 2>&1; then
+        ip link del "${VETH_BR}" || exitFailed
+    fi
 
     if ! ip link add "${VETH_BR}" type veth peer name "${VETH_NS}"; then exitFailed; fi
 

--- a/backend/apps/kloudust/lib/cmd/scripts/deleteRouter.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/deleteRouter.sh
@@ -3,7 +3,7 @@
 # Params
 # {1}Router Name - no spaces
 
-NAME="{1}"
+ROUTER_NAME="{1}"
 
 ROUTER_BOOT_SCRIPT="/kloudust/system/hostinit/30router_${ROUTER_NAME}.sh"
 
@@ -12,8 +12,8 @@ function exitFailed() {
     exit 1
 }
 
-if ! ip netns delete $NAME; then exitFailed; fi
+if ! ip netns delete $ROUTER_NAME; then exitFailed; fi
 
 rm $ROUTER_BOOT_SCRIPT
-printf "\n\nRouter $NAME deleted successfully"
+printf "\n\nRouter $ROUTER_NAME deleted successfully"
 exit 0

--- a/backend/apps/kloudust/lib/cmd/scripts/deleteRouter.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/deleteRouter.sh
@@ -5,6 +5,8 @@
 
 NAME="{1}"
 
+ROUTER_BOOT_SCRIPT="/kloudust/system/hostinit/30router_${ROUTER_NAME}.sh"
+
 function exitFailed() {
     echo Failed
     exit 1
@@ -12,5 +14,6 @@ function exitFailed() {
 
 if ! ip netns delete $NAME; then exitFailed; fi
 
+rm $ROUTER_BOOT_SCRIPT
 printf "\n\nRouter $NAME deleted successfully"
 exit 0

--- a/backend/apps/kloudust/lib/cmd/scripts/deleteRouter.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/deleteRouter.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Params
+# {1}Router Name - no spaces
+
+NAME="{1}"
+
+function exitFailed() {
+    echo Failed
+    exit 1
+}
+
+if ! ip netns delete $NAME; then exitFailed; fi
+
+printf "\n\nRouter $NAME deleted successfully"
+exit 0

--- a/backend/apps/kloudust/lib/dbAbstractor.js
+++ b/backend/apps/kloudust/lib/dbAbstractor.js
@@ -317,6 +317,25 @@ exports.addOrUpdateVMToDB = async (name, description, hostname, arch, os, cpus, 
 }
 
 /**
+ * Adds the given router to the catalog.
+ * @param {string} name The router name
+ * @param {string} name_raw The router name raw 
+ * @param {string} description The router description
+ * @param {string} hostname The hostname
+ * @param {string} project The project, if skipped is auto picked from the environment
+ * @param {string} org The org, if skipped is auto picked from the environment
+ * @return true on success or false otherwise
+ */
+exports.addOrUpdateRouterToDB = async (name, name_raw, description, hostname, project=KLOUD_CONSTANTS.env.prj(), org=KLOUD_CONSTANTS.env.org()) => {
+    if (!roleman.checkAccess(roleman.ACTIONS.edit_project_resource)) {_logUnauthorized(); return false;}
+    project = roleman.getNormalizedProject(project); org = roleman.getNormalizedOrg(org);
+
+    const id = `${org}_${project}_${name}`;
+    const query = "replace into routers(id, name, name_raw, description, hostname, org, projectid) values (?,?,?,?,?,?,?)";
+    return await _db().runCmd(query, [id, name, name_raw ,description, hostname, org, _getProjectID(project, org)]);
+}
+
+/**
  * Returns the VM for the current user, org and project given its name. 
  * @param {string} name The VM Name
  * @param {string} project The project, if skipped is auto picked from the environment
@@ -335,6 +354,24 @@ exports.getVM = async (name, project=KLOUD_CONSTANTS.env.prj(), org=KLOUD_CONSTA
         KLOUD_CONSTANTS.LOGERROR(`Unable to parse disks for VM ${vm.name}`); vm.disks = [];
     };
     return vm;
+}
+
+/**
+ * Returns the router for the current user, org and project given its name. 
+ * @param {string} name The router Name
+ * @param {string} project The project, if skipped is auto picked from the environment
+ * @param {string} org The org, if skipped is auto picked from the environment
+ * @return VM object or null
+ */
+exports.getRouter = async (name, project=KLOUD_CONSTANTS.env.prj(), org=KLOUD_CONSTANTS.env.org()) => {
+    if (!roleman.checkAccess(roleman.ACTIONS.lookup_project_resource)) {_logUnauthorized(); return false;}
+    project = roleman.getNormalizedProject(project); org = roleman.getNormalizedOrg(org);
+
+    const router_id = `${org}_${project}_${name}`, 
+        results = await _db().getQuery("select * from routers where id = ? collate nocase", [router_id]);
+    
+    if ((!results) || (!results.length)) return null;
+    return results[0];
 }
 
 /**
@@ -377,6 +414,27 @@ exports.deleteVM = async (name, project=KLOUD_CONSTANTS.env.prj(), org=KLOUD_CON
     const deletionResult = await _db().runCmd("delete from vms where id = ? collate nocase", [vmid]);
     if (deletionResult) if (!await this.addObjectToRecycleBin(vmid, vm, project, org)) 
         KLOUD_CONSTANTS.LOGWARN(`Unable to add VM ${name} to the recycle bin.`);
+    return deletionResult;
+}
+
+/**
+ * Deletes the router for the current user, org and project given its name. Moves the object to the
+ * recycle bin as well.
+ * @param {string} name The Router Name
+ * @param {string} project The project, if skipped is auto picked from the environment
+ * @param {string} org The org, if skipped is auto picked from the environment
+ * @return true on success or false otherwise
+ */
+exports.deleteRouter = async (name, project=KLOUD_CONSTANTS.env.prj(), org=KLOUD_CONSTANTS.env.org()) => {
+    if (!roleman.checkAccess(roleman.ACTIONS.edit_project_resource)) {_logUnauthorized(); return false;}
+    project = roleman.getNormalizedProject(project); org = roleman.getNormalizedOrg(org);
+
+    const router = await exports.getRouter(name, project, org); if (!router) return true; // doesn't exist in the DB anyways
+
+    const router_id = `${org}_${project}_${name}`;
+    const deletionResult = await _db().runCmd("delete from routers where id = ? collate nocase", [router_id]);
+    if (deletionResult) if (!await this.addObjectToRecycleBin(router_id, router, project, org)) 
+        KLOUD_CONSTANTS.LOGWARN(`Unable to add Router ${name} to the recycle bin.`);
     return deletionResult;
 }
 
@@ -1192,6 +1250,13 @@ exports.getHostForIP = async function(ip, for_allocation) {
     return results[0]?.hostname;
 }
 
+exports.getHostWithVnets = async function(vnet_ids) {
+    if (!roleman.checkAccess(roleman.ACTIONS.lookup_project_resource)) {_logUnauthorized(); return false;}
+    const query = `SELECT pk2 AS hostname, COUNT(*) AS matched_vnet_count, GROUP_CONCAT(pk1) AS matched_vnets FROM relationships WHERE type='vnethost' AND pk1 IN (${vnet_ids.map(_=>"?").join(",")}) GROUP BY pk2 ORDER BY matched_vnet_count DESC LIMIT 1;`;
+    const results = await _db().getQuery(query, vnet_ids);
+    return results[0];
+}
+
 /**
  * Returns an IP that can be assigned to vms
  * @returns An IP that can be assigned to vms
@@ -1206,6 +1271,26 @@ exports.getAssignableIP = async function(hostname) {
 }
 
 /**
+ * Adds the given IP to resource Vnet
+ * @param {string} resource_name The resource name
+ * @param {string} vnet_name The Vnet name
+ * @param {string} ip IP
+ * @param {string} project The project, if skipped is auto picked from the environment
+ * @param {string} org The org, if skipped is auto picked from the environment
+ * @returns true on success or false on failure
+ */
+exports.addResourceVnetIP = async function(resource_name, vnet_name, ip, relation, project=KLOUD_CONSTANTS.env.prj(), org=KLOUD_CONSTANTS.env.org()) {
+    if (!roleman.checkAccess(roleman.ACTIONS.edit_project_resource)) {_logUnauthorized(); return false;}
+    
+    const resource_id = `${org}_${project}_${resource_name}`;
+    const vnet_id = `${org}_${project}_${vnet_name}`;
+
+    const cmd = "insert into relationships (pk1, pk2, pk3, type) values (?,?,?,?)", params =  [resource_id, vnet_id, ip, relation];
+    const insertResult = await _db().runCmd(cmd, params);
+    return insertResult;
+}
+
+/**
  * Adds the given IP to VM Vnet
  * @param {string} vm_name The VM name
  * @param {string} vnet_name The Vnet name
@@ -1214,16 +1299,18 @@ exports.getAssignableIP = async function(hostname) {
  * @param {string} org The org, if skipped is auto picked from the environment
  * @returns true on success or false on failure
  */
-exports.addVMVnetIP = async function(vm_name, vnet_name, ip, project=KLOUD_CONSTANTS.env.prj(), org=KLOUD_CONSTANTS.env.org()) {
-    if (!roleman.checkAccess(roleman.ACTIONS.edit_project_resource)) {_logUnauthorized(); return false;}
-    
-    const vm_id = `${org}_${project}_${vm_name}`;
-    const vnet_id = `${org}_${project}_${vnet_name}`;
+exports.addVMVnetIP = async (vm_name, vnet_name, ip, project=KLOUD_CONSTANTS.env.prj(), org=KLOUD_CONSTANTS.env.org()) => exports.addResourceVnetIP(vm_name, vnet_name, ip, 'vmvnetip', project, org);
 
-    const cmd = "insert into relationships (pk1, pk2, pk3, type) values (?,?,?,?)", params =  [vm_id, vnet_id, ip,'vmvnetip'];
-    const insertResult = await _db().runCmd(cmd, params);
-    return insertResult;
-}
+/**
+ * Adds the given IP to router Vnet
+ * @param {string} router_name The router name
+ * @param {string} vnet_name The Vnet name
+ * @param {string} ip IP
+ * @param {string} project The project, if skipped is auto picked from the environment
+ * @param {string} org The org, if skipped is auto picked from the environment
+ * @returns true on success or false on failure
+ */
+exports.addRouterVnetIP = async (router_name, vnet_name, ip, project=KLOUD_CONSTANTS.env.prj(), org=KLOUD_CONSTANTS.env.org()) => exports.addResourceVnetIP(router_name, vnet_name, ip, 'routervnetip', project, org);
 
 /**
  * Removes the given IP from VM Vnet
@@ -1246,20 +1333,38 @@ exports.removeVMVnetIP = async function(vm_name, vnet_name, ip, project=KLOUD_CO
 }
 
 /**
+ * Removes all vmvnetip relationships for the given resource
+ * @param {string} resource_name The resource name
+ * @param {string} project The project, if skipped is auto picked from the environment
+ * @param {string} org The org, if skipped is auto picked from the environment
+ * @returns true on success or false on failure
+ */
+exports.removeAllResourceVnetIPRelationships = async function(resource_name, relation_name, project=KLOUD_CONSTANTS.env.prj(), org=KLOUD_CONSTANTS.env.org()) {
+    if (!roleman.checkAccess(roleman.ACTIONS.edit_project_resource)) {_logUnauthorized(); return false;}
+    
+    const resource_id = `${org}_${project}_${resource_name}`;
+    const cmd = "delete from relationships where pk1 = ? and type = ?", params =  [resource_id, relation_name];
+    const deleteResult = await _db().runCmd(cmd, params);
+    return deleteResult;
+}
+
+/**
  * Removes all vmvnetip relationships for the given VM
  * @param {string} vm_name The VM name
  * @param {string} project The project, if skipped is auto picked from the environment
  * @param {string} org The org, if skipped is auto picked from the environment
  * @returns true on success or false on failure
  */
-exports.removeAllVMVnetIPRelationships = async function(vm_name, project=KLOUD_CONSTANTS.env.prj(), org=KLOUD_CONSTANTS.env.org()) {
-    if (!roleman.checkAccess(roleman.ACTIONS.edit_project_resource)) {_logUnauthorized(); return false;}
-    
-    const vm_id = `${org}_${project}_${vm_name}`;
-    const cmd = "delete from relationships where pk1 = ? and type = ?", params =  [vm_id, 'vmvnetip'];
-    const deleteResult = await _db().runCmd(cmd, params);
-    return deleteResult;
-}
+exports.removeAllVMVnetIPRelationships = async (vm_name, project=KLOUD_CONSTANTS.env.prj(), org=KLOUD_CONSTANTS.env.org()) => exports.removeAllResourceVnetIPRelationships(vm_name, 'vmvnetip', project, org)
+
+/**
+ * Removes all vmvnetip relationships for the given router
+ * @param {string} router_name The router name
+ * @param {string} project The project, if skipped is auto picked from the environment
+ * @param {string} org The org, if skipped is auto picked from the environment
+ * @returns true on success or false on failure
+ */
+exports.removeAllRouterVnetIPRelationships = async (router_name, project=KLOUD_CONSTANTS.env.prj(), org=KLOUD_CONSTANTS.env.org()) => exports.removeAllResourceVnetIPRelationships(router_name, 'routervnetip', project, org)
 
 /**
  * Removes the given IP from VM Vnet


### PR DESCRIPTION
This pull implements the router feature using linux networks namespaces.
Commit 1 : Adds the routers tables in db schema
Commit 2 : Adds the create router feature
Commit 3 : Adds the delete router feature
Commit 4 : Adds the supporting db functions for commits 2 and 3

Core Idea :

Given the the router name, vnet list and gateway ips for each vnet the createRouter command
1. Creates a Linux network namespace for the router.
2. Creates one veth pair for each connected vnet.
3. Attaches one end of each veth pair to the vnet's main bridge.
4. Moves the other end of the veth pair into the router namespace.
5. Assigns the configured gateway IP address to the namespace-side interface.
6. Enables IP forwarding within the namespace, allowing traffic to be routed between connected networks.
