### PR TITLE
[Fix] Conflict when different routers have same vnets

### DIFF
--- a/backend/apps/kloudust/lib/cmd/createRouter.js
+++ b/backend/apps/kloudust/lib/cmd/createRouter.js
@@ -36,7 +36,7 @@ module.exports.exec = async function(params) {
     const vnet_promises = vnets.map(async vnet => {
         const vnet_details = await dbAbstractor.getVnet(vnetModule.resolveVnetName(vnet.vnet));
         if (!vnet_details) return false;
-        return { ...vnet_details, gateway_address: vnet.ip, vnet_name_hash: crypto.createHash('sha256').update(vnet_details.name,'utf8').digest('hex').slice(0,12) };
+        return { ...vnet_details, gateway_address: vnet.ip, vnet_name_hash: crypto.createHash('sha256').update(router_name+vnet_details.name,'utf8').digest('hex').slice(0,12) };
     });
 
     const vnet_infos = await Promise.all(vnet_promises);


### PR DESCRIPTION
When two different router were created that contained same vnets, the interface names were causing conflict and were getting removed from the old router and added to the new router, this pull fixes it by making them unique on the basis of router name+vnet_name