### PR TITLE
Fixed protocol matching

### DIFF
--- a/backend/apps/kloudust/lib/cmd/scripts/applyFirewallRuleset.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/applyFirewallRuleset.sh
@@ -103,7 +103,7 @@ while read -r rule; do
     PORT_MATCH=""
     if { [ "$PROTOCOL" = "tcp" ] || [ "$PROTOCOL" = "udp" ]; } && [ -n "$PORT" ] && [ "$PORT" != "null" ] && [ "$PORT" != "*" ]; then
         PORT_MATCH="$PROTOCOL dport $PORT"
-    elif [ "$PROTOCOL" != "*" ] && [ "$PROTOCOL" != "null" ] && [ -n "$PROTOCOL" ]; then
+    elif [ "$PROTOCOL" != "*" ] && [ "$PROTOCOL" != "null" ] && [ "$PROTOCOL" != "all" ] && [ -n "$PROTOCOL" ]; then
         PROTOCOL_MATCH="ip protocol $PROTOCOL"
     fi
 


### PR DESCRIPTION
## Issue 
Firewall ruleset cannot be applied to a VM when a rule uses TCP + UDP protocol

## Reason
When a rule is created with protocol set to tcp + udp (represented internally as all), the code enters the elif condition because PROTOCOL is neither * nor null. This generates ip protocol all, which is not supported by nftables and causes rule creation to fail.

## Fix 

Added a check for all in the elif condition [ “$PROTOCOL” != “all” ]. When the protocol is all, leave PROTOCOL_MATCH empty instead of generating ip protocol all.