### PR TITLE
Fixed delete firewall button

### DIFF
--- a/frontend/apps/kloudust/commands/forms/manage.form.json
+++ b/frontend/apps/kloudust/commands/forms/manage.form.json
@@ -8,7 +8,7 @@
     {"id": "snapshots", "label": "{{{i18n.VirtualMachineSnapshots}}}", "logo": "img/snapshot.svg"},
     {"id": "deletevm", "label": "{{{i18n.DeleteVirtualMachine}}}", "logo": "img/deletevm_manage.svg"},
     {"id": "deletevnet", "label": "{{{i18n.DeleteVirtualNetwork}}}", "logo": "img/deletevnet.svg"},
-    {"id": "deletefirewall", "label": "{{{i18n.DeleteFirewall}}}", "logo": "img/deletefirewall.svg"},
+    {"id": "deletefirewallruleset", "label": "{{{i18n.DeleteFirewall}}}", "logo": "img/deletefirewall.svg"},
     {"id": "deleterouter", "label": "{{{i18n.DeleteRouter}}}", "logo": "img/deleterouter_manage.svg"}
 ]
 },


### PR DESCRIPTION
## Issue 
The delete firewall button was not working (not clickable)
## Fix 
ID was wrong in the manage form, now fixed
