### PR TITLE
[minor-fix] frontent dynamic url to allow all the ports dynamically | [add] dma config for enable/disable loginapp DMA via conf

### DIFF
--- a/frontend/apps/kloudust/3p/tkmlogin.mjs
+++ b/frontend/apps/kloudust/3p/tkmlogin.mjs
@@ -24,7 +24,7 @@ async function login(appname, redirect, otkapi, bgcolor, unifiedloginbaseurl=UNI
         console.error(`OTK API failed for Tekmonks Unified Login, error was undefined OTK.`); return; }
 
     // call tekmonks unified login
-    const search = `an=${encodeURIComponent(appname)}&rdr=${encodeURIComponent(redirect)}&otk=${encodeURIComponent(onetimekey)}${bgcolor?`&bgc=${encodeURIComponent(bgcolor)}`:""}`;
+    const search = `an=${encodeURIComponent(appname)}&rdr=${encodeURIComponent(redirect)}&otk=${encodeURIComponent(onetimekey)}${bgcolor?`&bgc=${encodeURIComponent(bgcolor)}`:""}${APP_CONSTANTS.TKMLOGINAPP_DISABLE_MFA?`&${APP_CONSTANTS.TKMLOGINAPP_DISABLE_MFA_KEY}=${APP_CONSTANTS.TKMLOGINAPP_DISABLE_MFA}`:""}`;
     window.location.replace(`${unifiedloginbaseurl}?${search}`);
 }
 

--- a/frontend/apps/kloudust/conf/app.json
+++ b/frontend/apps/kloudust/conf/app.json
@@ -10,6 +10,9 @@
         "components/form-runner", "components/table-list", "components/firewall-rules", "components/router-vnets" ],
     "APP_ABOUT_URL": "https://tekmonks.com/",
     "TKMLOGINAPP_URL": "https://login.tekmonks.com",
+    "TKMLOGINAPP_DISABLE_MFA_KEY": "dma",
+    "TKMLOGINAPP_DISABLE_MFA": false,
+    
     "INSECURE_DEVELOPMENT_MODE": true,
     "VM_TYPE_VM": "vm",
     "VM_TYPES_SERVICES": ["windowsvdi", "oracledbaas", "mariadbaas"]

--- a/frontend/apps/kloudust/js/application.mjs
+++ b/frontend/apps/kloudust/js/application.mjs
@@ -39,7 +39,7 @@ const main = async _ => {
 	await _addPageLoadInterceptors(); await _registerComponents();
 
 	const decodedURL = new URL($$.librouter.decodeURL(window.location.href)), 
-		justURL = new URL(`${decodedURL.protocol}//${decodedURL.hostname}${decodedURL.pathname}`).href;
+		justURL = new URL(`${decodedURL.protocol}//${decodedURL.host}${decodedURL.pathname}`).href;
 	if ($$.libsecurityguard.isAllowed(justURL)) $$.librouter.loadPage(decodedURL.href);
 	else $$.librouter.loadPage(APP_CONSTANTS.LOGIN_HTML);
 }


### PR DESCRIPTION
Issue 1: Developers have to add the frontend port manually in the `application.mjs` if not using 443
Fix 1: Used the dynamic host from the URL (hostname:port) in the `application.mjs`

Issue 2: The login app multifactor authentication was not configurable
Fix: Added configuration for multifactor authentication