### PR TITLE
[FIX] fix for KD host firewall Persistence

### DIFF
--- a/backend/apps/kloudust/lib/cmd/scripts/addHost.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/addHost.sh
@@ -277,7 +277,15 @@ if ! sudo nft add rule inet kdhostfirewall input tcp dport $NEW_SSH_PORT accept;
 if ! sudo nft add rule inet kdhostfirewall input tcp dport $AGENT_PORT accept; then exitFailed; fi          #Agent port
 if ! sudo nft add rule inet kdhostfirewall input udp dport 8472 accept; then exitFailed; fi   # VxLAN port
 if ! sudo nft add chain inet kdhostfirewall input { policy drop\; }; then exitFailed; fi
-if ! sudo nft list ruleset | sudo tee /etc/nftables.conf > /dev/null; then exitFailed; fi 
+
+# Kloudust Host based firewall and persistence.
+if ! sudo mkdir -p /etc/nftables.d; then exitFailed; fi
+sudo tee /etc/nftables.conf > /dev/null <<'EOF'
+#!/usr/sbin/nft -f
+include "/etc/nftables.d/*.nft"
+EOF
+if [ $? -ne 0 ]; then exitFailed; fi
+if ! { echo "table inet kdhostfirewall"; echo "delete table inet kdhostfirewall"; sudo nft list table inet kdhostfirewall; } | sudo tee /etc/nftables.d/kdhostfirewall.nft > /dev/null; then exitFailed; fi 
 if ! sudo systemctl enable nftables; then exitFailed; fi                                  # Reboot will enforce the firewall
 # Setup IP forwarding and ARP forwarding support
 if ! echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward > /dev/null; then exitFailed; fi   

--- a/backend/apps/kloudust/lib/cmd/scripts/removeFirewallRuleset.sh
+++ b/backend/apps/kloudust/lib/cmd/scripts/removeFirewallRuleset.sh
@@ -40,9 +40,7 @@ if [ -f "/kloudust/system/firewall/fw_${VM_NAME}_${VNET_NAME}.sh" ]; then
     if ! rm -f "/kloudust/system/firewall/fw_${VM_NAME}_${VNET_NAME}.sh"; then exitFailed; fi
 fi
 
-# Persist
-if ! sudo nft list ruleset | sudo tee /etc/nftables.conf > /dev/null; then exitFailed; fi 
-if ! sudo systemctl enable nftables; then exitFailed; fi
+# No persist step needed - VM firewalls are added if VM is up using Hooks
 
 echo "Firewall rules removed for $VM_NAME, ruleset $RULESET_NAME and Vnet $VNET_ID"
 exit 0


### PR DESCRIPTION
**Changes Made:**
- `addHost.sh`: Firewall persistence now writes only the kdhostfirewall table to /etc/nftables.d/kdhostfirewall.nft (with a delete-then-recreate guard), and /etc/nftables.conf is reduced to an include of /etc/nftables.d/*.nft, instead of dumping the entire live ruleset into /etc/nftables.conf.
- `removeFirewallRuleset.sh`: Removed the persist step (nft list ruleset > /etc/nftables.conf and re-enabling nftables) after deleting a VM's firewall rules.

**Why the Changes were made:**
- Persisting the full live ruleset captured transient, VM-specific rules alongside the host firewall, so reboots restored stale VM rules and could overwrite/corrupt the host firewall config. Persisting only the host table keeps /etc/nftables.conf clean and reboot-safe.
- VM firewall rules don't need persisting on removal, they are re-applied via hooks when a VM comes up, so the persist step was redundant.